### PR TITLE
Added SecurityException check for location access

### DIFF
--- a/src/io/segment/android/info/Location.java
+++ b/src/io/segment/android/info/Location.java
@@ -30,11 +30,16 @@ public class Location implements Info<JSONObject> {
 		
 		EasyJSONObject object = new EasyJSONObject();
 
-		if (provider != null) {
-			android.location.Location location = locationManager
-					.getLastKnownLocation(provider);
-	
-			
+        if (provider != null) {
+            android.location.Location location;
+
+            try {
+                location = locationManager.getLastKnownLocation(provider);
+            } catch (SecurityException ex) {
+                //The application may not have permission to access location
+                location = null;
+            }
+
 			if (location != null) {
 				object.put("latitude", location.getLatitude());
 				object.put("longitude", location.getLongitude());


### PR DESCRIPTION
On a few devices (one of which is the Galaxy S4 Google Play edition), we're seeing crash reports when trying to access location with the following stack trace:

```
Caused by: java.lang.SecurityException: "gps" location provider requires ACCESS_FINE_LOCATION permission.
       at android.os.Parcel.readException(Parcel.java:1431)
       at android.os.Parcel.readException(Parcel.java:1385)
       at android.location.ILocationManager$Stub$Proxy.getLastLocation(ILocationManager.java:651)
       at android.location.LocationManager.getLastKnownLocation(LocationManager.java:1146)
       at io.segment.android.info.Location.get(Location.java:35)
       at io.segment.android.info.Location.get(Location.java:1)
       at io.segment.android.info.InfoManager.build(InfoManager.java:43)
       at io.segment.android.Analytics.initialize(Analytics.java:364)
       at io.segment.android.Analytics.initialize(Analytics.java:300)
```

Our application doesn't require ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permissions, and should be able to function without location according to the Android library documentation:

> You’re not required to include any permission that you’re not comfortable with (except for INTERNET and ACCESS_NETWORK_STATE, which are required). Note that that some analytics services will not work well without their respective permissions.
