### PR TITLE
Remove the 'Viewed' from the screen name

### DIFF
--- a/src/io/segment/android/models/Screen.java
+++ b/src/io/segment/android/models/Screen.java
@@ -21,7 +21,7 @@ public class Screen extends Track {
 				 Calendar timestamp,
 				 Context context) {
 
-		super(sessionId, userId, "Viewed " + name, properties, timestamp, context);
+		super(sessionId, userId, name, properties, timestamp, context);
 
 		put("action", ACTION);
 		


### PR DESCRIPTION
The screenName that is sent should not be changed by this library. This changes the data the user wants to track...
The really annoying thing is that the iOS library does not prepend the "Viewed". 
So tracking the same screen ("profile") on both platforms results in 2 different screens ("Viewed profile" and "profile").
I prefer removing the "Viewed" here instead of adding it to the iOS library as well, because the library isn't supposed to change the screen names the user wants to track.
