### PR TITLE
Crittercism: Update SDK version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Version 2.3.1 (November 11th, 2014)
 ===================================
-* Improvement: Updating the Crittercism SDK version from 4.5.3 to 5.1.0
+* Improvement: Updating the Crittercism SDK version from 4.5.3 to 5.0.3
 
 Version 2.3.0 (November 10th, 2014)
 ====================================

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ ext.libraries = [
     appsFlyer      : files('libs/AppsFlyer-2.3.1.12.jar'),
     bugsnag        : 'com.bugsnag:bugsnag-android:2.2.0',
     countly        : 'ly.count:sdk-android:13.11',
-    crittercism    : 'com.crittercism:crittercism-android-agent:5.1.0',
+    crittercism    : 'com.crittercism:crittercism-android-agent:5.0.3',
     flurry         : files('libs/Flurry-4.1.0.jar'),
     supportLib     : 'com.android.support:support-v4:20.0.0',
     googleAnalytics: 'com.google.android.gms:play-services:6.1.11',


### PR DESCRIPTION
Updating Crittercism SDK version from 4.5.3 to 5.1.0. No breaking changes - http://docs.crittercism.com/release_notes/release_notes_android.html

@f2prateek 
