### PR TITLE
fix Analytics#alias method 

### DIFF
--- a/core/src/main/java/com/segment/analytics/Analytics.java
+++ b/core/src/main/java/com/segment/analytics/Analytics.java
@@ -438,7 +438,7 @@ public class Analytics {
     }
 
     BasePayload payload = new AliasPayload(traitsCache.get().anonymousId(), analyticsContext,
-        traitsCache.get().userId(), previousId, options);
+            newId, previousId, options);
     submit(payload);
   }
 


### PR DESCRIPTION
Hi,
I found out that a parameter 'newId' in Analytics#alias() is never used.
I think 'newId' should be an argument of AliasPayload(). 
So I fixed it. Please review. 
