### PR TITLE
Referral Tracking

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -29,6 +29,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.Uri;
 import android.os.Build;
 import android.telephony.TelephonyManager;
 import android.util.DisplayMetrics;
@@ -321,6 +322,15 @@ public class AnalyticsContext extends ValueMap {
     private static final String CAMPAIGN_TERM_KEY = "term";
     private static final String CAMPAIGN_CONTENT_KEY = "content";
 
+    static Campaign parse(String referrer) {
+      Uri uri = Uri.parse(referrer);
+      return new Campaign().putName(uri.getQueryParameter("utm_campaign"))
+          .putSource(uri.getQueryParameter("utm_source"))
+          .putMedium(uri.getQueryParameter("utm_medium"))
+          .putTerm(uri.getQueryParameter("utm_term"))
+          .putContent(uri.getQueryParameter("utm_content"));
+    }
+
     // Public Constructor
     public Campaign() {
     }
@@ -367,7 +377,7 @@ public class AnalyticsContext extends ValueMap {
       return putValue(CAMPAIGN_TERM_KEY, term);
     }
 
-    public String tern() {
+    public String term() {
       return getString(CAMPAIGN_TERM_KEY);
     }
 
@@ -378,6 +388,21 @@ public class AnalyticsContext extends ValueMap {
 
     public String content() {
       return getString(CAMPAIGN_CONTENT_KEY);
+    }
+
+    @Override public String toString() {
+      return "Campaign{"
+          + "name="
+          + name()
+          + ", source="
+          + source()
+          + ", medium="
+          + medium()
+          + ", term="
+          + term()
+          + ", content="
+          + content()
+          + '}';
     }
   }
 

--- a/analytics-core/src/main/java/com/segment/analytics/InstallReferrerReceiver.java
+++ b/analytics-core/src/main/java/com/segment/analytics/InstallReferrerReceiver.java
@@ -1,0 +1,23 @@
+package com.segment.analytics;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * A {@link BroadcastReceiver} for automatically attaching Google Play Store referrer information
+ * to the {@link AnalyticsContext}.
+ * <p/>
+ * Clients may subclass this and override {@link #getAnalytics(Context)} to provide custom
+ * instances of {@link Analytics} client. This should be the same instance used to track events
+ * through the rest of your app.
+ */
+public class InstallReferrerReceiver extends BroadcastReceiver {
+  @Override public void onReceive(Context context, Intent intent) {
+    getAnalytics(context).setInstallReferrer(context, intent);
+  }
+
+  protected Analytics getAnalytics(Context context) {
+    return Analytics.with(context);
+  }
+}

--- a/analytics-core/src/main/java/com/segment/analytics/IntegrationManager.java
+++ b/analytics-core/src/main/java/com/segment/analytics/IntegrationManager.java
@@ -2,6 +2,8 @@ package com.segment.analytics;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -32,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
 import static com.segment.analytics.Analytics.Callback;
+import static com.segment.analytics.AnalyticsContext.Campaign;
 import static com.segment.analytics.internal.Utils.THREAD_PREFIX;
 import static com.segment.analytics.internal.Utils.buffer;
 import static com.segment.analytics.internal.Utils.closeQuietly;
@@ -325,6 +328,10 @@ class IntegrationManager implements Application.ActivityLifecycleCallbacks {
 
   void dispatchFlush() {
     dispatchEnqueue(IntegrationOperation.flush());
+  }
+
+  void dispatchInstallReferrer(Campaign campaign, Context context, Intent intent) {
+    dispatchEnqueue(IntegrationOperation.installReferrer(campaign, context, intent));
   }
 
   void dispatchEnqueue(BasePayload basePayload) {

--- a/analytics-core/src/main/java/com/segment/analytics/IntegrationOperation.java
+++ b/analytics-core/src/main/java/com/segment/analytics/IntegrationOperation.java
@@ -1,6 +1,8 @@
 package com.segment.analytics;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import com.segment.analytics.internal.AbstractIntegration;
 import com.segment.analytics.internal.model.payloads.AliasPayload;
@@ -9,6 +11,7 @@ import com.segment.analytics.internal.model.payloads.IdentifyPayload;
 import com.segment.analytics.internal.model.payloads.ScreenPayload;
 import com.segment.analytics.internal.model.payloads.TrackPayload;
 
+import static com.segment.analytics.AnalyticsContext.Campaign;
 import static com.segment.analytics.Options.ALL_INTEGRATIONS_KEY;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
@@ -211,6 +214,19 @@ abstract class IntegrationOperation {
 
       @Override public String toString() {
         return "Flush";
+      }
+    };
+  }
+
+  static IntegrationOperation installReferrer(final Campaign campaign, final Context context,
+      final Intent intent) {
+    return new IntegrationOperation() {
+      @Override public void run(AbstractIntegration integration, ProjectSettings projectSettings) {
+        integration.installReferrer(campaign, intent, context);
+      }
+
+      @Override public String toString() {
+        return "InstallReferrer{" + "campaign=" + campaign + ", intent=" + intent + '}';
       }
     };
   }

--- a/analytics-core/src/main/java/com/segment/analytics/internal/AbstractIntegration.java
+++ b/analytics-core/src/main/java/com/segment/analytics/internal/AbstractIntegration.java
@@ -2,6 +2,7 @@ package com.segment.analytics.internal;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.internal.model.payloads.AliasPayload;
@@ -11,6 +12,7 @@ import com.segment.analytics.internal.model.payloads.ScreenPayload;
 import com.segment.analytics.internal.model.payloads.TrackPayload;
 
 import static com.segment.analytics.Analytics.LogLevel;
+import static com.segment.analytics.AnalyticsContext.Campaign;
 
 /**
  * A base class for all bundled integrations.
@@ -82,6 +84,10 @@ public abstract class AbstractIntegration<T> {
   }
 
   public void flush() {
+
+  }
+
+  public void installReferrer(Campaign campaign, Intent intent, Context context) {
 
   }
 }

--- a/analytics-core/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -78,6 +78,21 @@ public class AnalyticsContextTest {
     }
   }
 
+  @Test public void referrer() {
+    String referrer = "http://segment.com?"
+        + "utm_campaign=blog&"
+        + "utm_medium=social&"
+        + "utm_source=facebook&"
+        + "utm_term=marketing+software&"
+        + "utm_content=sidebarlink";
+    assertThat(AnalyticsContext.Campaign.parse(referrer)).hasSize(5)
+        .containsEntry("name", "blog")
+        .containsEntry("medium", "social")
+        .containsEntry("source", "facebook")
+        .containsEntry("term", "marketing software")
+        .containsEntry("content", "sidebarlink");
+  }
+
   @Test public void copyIsImmutable() {
     AnalyticsContext copy = analyticsContext.unmodifiableCopy();
 

--- a/analytics-integrations/google-analytics/src/main/java/com/segment/analytics/internal/integrations/GoogleAnalyticsIntegration.java
+++ b/analytics-integrations/google-analytics/src/main/java/com/segment/analytics/internal/integrations/GoogleAnalyticsIntegration.java
@@ -3,12 +3,15 @@ package com.segment.analytics.internal.integrations;
 import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import com.google.android.gms.analytics.ExceptionReporter;
 import com.google.android.gms.analytics.GoogleAnalytics;
 import com.google.android.gms.analytics.HitBuilders;
 import com.google.android.gms.analytics.Logger;
 import com.google.android.gms.analytics.Tracker;
+import com.google.android.gms.tagmanager.InstallReferrerReceiver;
 import com.segment.analytics.Analytics;
+import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.Properties;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.internal.AbstractIntegration;
@@ -160,6 +163,13 @@ public class GoogleAnalyticsIntegration extends AbstractIntegration<Tracker> {
       return true;
     }
     return false;
+  }
+
+  @Override public void installReferrer(AnalyticsContext.Campaign campaign, Intent intent,
+      Context context) {
+    super.installReferrer(campaign, intent, context);
+
+    new InstallReferrerReceiver().onReceive(context, intent);
   }
 
   @Override public Tracker getUnderlyingInstance() {

--- a/analytics-integrations/mixpanel/src/main/java/com/segment/analytics/internal/integrations/MixpanelIntegration.java
+++ b/analytics-integrations/mixpanel/src/main/java/com/segment/analytics/internal/integrations/MixpanelIntegration.java
@@ -2,7 +2,9 @@ package com.segment.analytics.internal.integrations;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
+import com.mixpanel.android.mpmetrics.InstallReferrerReceiver;
 import com.mixpanel.android.mpmetrics.MixpanelAPI;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
@@ -21,6 +23,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import static com.segment.analytics.Analytics.LogLevel;
+import static com.segment.analytics.AnalyticsContext.Campaign;
 import static com.segment.analytics.internal.Utils.debug;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
@@ -167,6 +170,12 @@ public class MixpanelIntegration extends AbstractIntegration<MixpanelAPI> {
     } else {
       event(track.event(), track.properties());
     }
+  }
+
+  @Override public void installReferrer(Campaign campaign, Intent intent, Context context) {
+    super.installReferrer(campaign, intent, context);
+
+    new InstallReferrerReceiver().onReceive(context, intent);
   }
 
   void event(String name, Properties properties) {

--- a/analytics-integrations/tapstream/src/main/java/com/segment/analytics/internal/integrations/TapstreamIntegration.java
+++ b/analytics-integrations/tapstream/src/main/java/com/segment/analytics/internal/integrations/TapstreamIntegration.java
@@ -2,7 +2,9 @@ package com.segment.analytics.internal.integrations;
 
 import android.app.Application;
 import android.content.Context;
+import android.content.Intent;
 import android.util.Log;
+import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.Properties;
 import com.segment.analytics.ValueMap;
 import com.segment.analytics.internal.AbstractIntegration;
@@ -13,6 +15,7 @@ import com.tapstream.sdk.Config;
 import com.tapstream.sdk.Event;
 import com.tapstream.sdk.Logger;
 import com.tapstream.sdk.Logging;
+import com.tapstream.sdk.ReferrerReceiver;
 import com.tapstream.sdk.Tapstream;
 import java.util.Map;
 
@@ -83,6 +86,13 @@ public class TapstreamIntegration extends AbstractIntegration<Tapstream> {
       tapstream.fireEvent(
           makeEvent(String.format(VIEWED_EVENT_FORMAT, screen.name()), screen.properties()));
     }
+  }
+
+  @Override public void installReferrer(AnalyticsContext.Campaign campaign, Intent intent,
+      Context context) {
+    super.installReferrer(campaign, intent, context);
+
+    new ReferrerReceiver().onReceive(context, intent);
   }
 
   private Event makeEvent(String name, Properties properties) {


### PR DESCRIPTION
This is the first step towards making it easier to track install referrals.

##### Next Steps
- [x] Provide a `BroadcastReceiver` implementation that clients can register.
- [x] Forward to bundled integrations.