### PR TITLE
Update Amplitude integration to 1.5.0

### DIFF
--- a/analytics-integrations/amplitude/build.gradle
+++ b/analytics-integrations/amplitude/build.gradle
@@ -1,5 +1,5 @@
 apply from: rootProject.file('gradle/integration.gradle')
 
 dependencies {
-  compile 'com.amplitude:android-sdk:1.4.3'
+  compile 'com.amplitude:android-sdk:1.5.0'
 }

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -21,5 +21,10 @@ android {
     sourceCompatibility rootProject.ext.compileJavaVersion
     targetCompatibility rootProject.ext.compileJavaVersion
   }
-}
 
+  // Ignore InvalidPackage from okio package.
+  // See https://github.com/square/okio/issues/58
+  lintOptions {
+    lintConfig file(new File(System.getProperty("user.dir"), "./gradle/lint.xml"))
+  }
+}

--- a/gradle/lint.xml
+++ b/gradle/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="InvalidPackage">
+        <ignore regexp="okio-\d+.\d+.\d+.jar" />
+    </issue>
+</lint>


### PR DESCRIPTION
* Add PinnedAmplitudeClient to support SSL pinning.
* Deprecate static methods on Amplitude. Switch to using Amplitude.getInstance().
* Upgrade HTTP client to okhttp.
* Fix bug when initializing with user id. Api key was not set properly.
* Expose setUserProperties(JSONObject, boolean) as a static
* Handle null edge cases in location request
* Add user opt out support
* Merge user properties in setUserProperties by default
* Refactor Amplitude to be a singleton to support tests
* Add option to disable fine-grained location tracking
* Fix crash: ConcurrentModificationException in HashMap
* Fix crash: CursorWindowAllocationException in SQLite