### PR TITLE
Guard against negative file length in QueueFile

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/QueueFile.java
+++ b/analytics-core/src/main/java/com/segment/analytics/QueueFile.java
@@ -143,8 +143,9 @@ class QueueFile implements Closeable {
     if (fileLength > raf.length()) {
       throw new IOException(
           "File is truncated. Expected length: " + fileLength + ", Actual length: " + raf.length());
-    } else if (fileLength == 0) {
-      throw new IOException("File is corrupt; length stored in header is 0.");
+    } else if (fileLength <= 0) {
+      throw new IOException(
+          "File is corrupt; length stored in header (" + fileLength + ") is invalid.");
     }
     elementCount = readInt(buffer, 4);
     int firstOffset = readInt(buffer, 8);

--- a/analytics-core/src/test/java/com/segment/analytics/QueueFileTest.java
+++ b/analytics-core/src/test/java/com/segment/analytics/QueueFileTest.java
@@ -133,9 +133,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
     try {
       new QueueFile(file);
-      fail("Should have complained about bad header length");
+      fail("Should have complained about bad header length.");
     } catch (IOException ex) {
-      assertThat(ex).hasMessage("File is corrupt; length stored in header is 0.");
+      assertThat(ex).hasMessage("File is corrupt; length stored in header (0) is invalid.");
+    }
+  }
+
+  @Test public void testNegativeSizeInHeaderComplains() throws IOException {
+    RandomAccessFile emptyFile = new RandomAccessFile(file, "rwd");
+    emptyFile.seek(0);
+    emptyFile.writeInt(-2147483648);
+    emptyFile.setLength(4096);
+    emptyFile.getChannel().force(true);
+    emptyFile.close();
+
+    try {
+      new QueueFile(file);
+      fail("Should have complained about bad header length.");
+    } catch (IOException ex) {
+      assertThat(ex) //
+          .hasMessage("File is corrupt; length stored in header (-2147483648) is invalid.");
     }
   }
 
@@ -354,8 +371,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     assertThat(queueFile.peek()).isEqualTo(values[99]);
   }
 
-  @SuppressWarnings("deprecation") @Test
-  public void testPeekWithElementReader() throws IOException {
+  @SuppressWarnings("deprecation") @Test public void testPeekWithElementReader()
+      throws IOException {
     QueueFile queueFile = new QueueFile(file);
     final byte[] a = {
         1, 2
@@ -508,8 +525,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     assertThat(iteration[0]).isEqualTo(2);
   }
 
-  @SuppressWarnings("deprecation") @Test
-  public void testForEachReadWithOffset() throws IOException {
+  @SuppressWarnings("deprecation") @Test public void testForEachReadWithOffset()
+      throws IOException {
     QueueFile queueFile = new QueueFile(file);
 
     queueFile.add(new byte[] {


### PR DESCRIPTION
We're seeing cases where `RandomAccessFile#write(byte[] buffer, int byteOffset, int byteCount)` is being called with a negative `byteCount`.

Ref #172.

```
java.lang.ArrayIndexOutOfBoundsException: length=4096; regionStart=0; regionLength=-1046
       at java.util.Arrays.checkOffsetAndCount(Arrays.java:1719)
       at libcore.io.IoBridge.write(IoBridge.java:491)
       at java.io.RandomAccessFile.write(RandomAccessFile.java:688)
       at com.segment.analytics.QueueFile.ringWrite(QueueFile.java:230)
       at com.segment.analytics.QueueFile.ringErase(QueueFile.java:239)
       at com.segment.analytics.QueueFile.remove(QueueFile.java:541)
       at com.segment.analytics.Segment.performFlush(Segment.java:151)
      ...
```

Looking at [`int beforeEof = fileLength - position;`](https://github.com/square/tape/blob/master/tape/src/main/java/com/squareup/tape/QueueFile.java#L228), this could happen when the fileLength is negative for some reason. This commit disallows a negative file length stored in the header during initialization.

