### PR TITLE
Tests that show EOFException (again)

### DIFF
--- a/analytics-core/build.gradle
+++ b/analytics-core/build.gradle
@@ -6,3 +6,9 @@ apply from: rootProject.file('gradle/checkstyle-library.gradle')
 apply from: rootProject.file('gradle/attach-jar.gradle')
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
+dependencies {
+
+    //testCompile 'junit:junit:4.12'
+    //androidTestCompile 'junit:junit:4.12'
+    androidTestCompile 'com.android.support.test:testing-support-lib:0.1'
+}

--- a/analytics-core/src/androidTest/java/com/segment/analytics/QueueFileStressTest.java
+++ b/analytics-core/src/androidTest/java/com/segment/analytics/QueueFileStressTest.java
@@ -1,0 +1,82 @@
+package com.segment.analytics;
+
+import android.content.Context;
+import android.test.AndroidTestCase;
+import android.test.RenamingDelegatingContext;
+
+import com.segment.analytics.internal.Utils;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by kellyfj on 5/8/15.
+ */
+public class QueueFileStressTest extends AndroidTestCase {
+
+    protected Context context;
+    protected static final String writeKey = "q1r1kn4a44";
+    private static Analytics analyticsInstance;
+    private static boolean firstTimeThrough = true;
+
+    @Override
+    protected void setUp() {
+        //delegates to the given context, but performs database and
+        // file operations with a renamed database/file
+        // name (prefixes default names with a given prefix).
+        context = new RenamingDelegatingContext(getContext(), "test_");
+        Analytics.Builder builder = new Analytics.Builder(context, writeKey);
+        analyticsInstance = builder.logLevel(Analytics.LogLevel.BASIC).build();
+    }
+
+    @Override
+    public void tearDown() throws IOException {
+        //Make sure any extra elements left over are flushed
+        //analyticsInstance.flush();
+        sleepUntilFlushTimerExpires();
+    }
+
+    public void testQueueFileUnderStress_track() {
+
+        Analytics.Builder builder = new Analytics.Builder(context, writeKey);
+        analyticsInstance = builder.logLevel(Analytics.LogLevel.VERBOSE).
+                flushInterval(300, TimeUnit.SECONDS).
+                flushQueueSize(250).
+                build();
+
+
+        int maxQueueSize = SegmentDispatcher.MAX_QUEUE_SIZE;
+        int aboveTheMax = 100;
+        int veryLargeFlushSize = maxQueueSize + aboveTheMax;
+
+
+        //WHEN we create enough events to cause a flush
+        List<Integer> idList = new ArrayList<Integer>();
+        //Avoid hitting the FLush Size
+        long id = System.currentTimeMillis();
+        for (int i = 1; i <= veryLargeFlushSize - 1; i++) {
+            id++;
+            analyticsInstance.track("FJK QueueFileStressTest - testQueueFileUnderStress_track", null, null);
+            analyticsInstance.screen("FJK QueueFileStressTest - testQueueFileUnderStress_screen", null);
+        }
+        analyticsInstance.flush();
+
+    }
+
+    public void sleepUntilFlushTimerExpires() {
+       sleep(Utils.DEFAULT_FLUSH_INTERVAL + 3000);
+    }
+
+    public void sleepUntilSettingsLoaded() {
+       sleep(60*1000);
+    }
+
+    public void sleep(long time) {
+        try {
+            Thread.sleep(time);
+        } catch (InterruptedException ignored) {
+        }
+    }
+}

--- a/analytics-core/src/androidTest/java/com/segment/analytics/QueueFileTest.java
+++ b/analytics-core/src/androidTest/java/com/segment/analytics/QueueFileTest.java
@@ -1,0 +1,146 @@
+package com.segment.analytics;
+
+import android.content.Context;
+import android.test.AndroidTestCase;
+import android.test.RenamingDelegatingContext;
+
+import java.io.*;
+import java.util.NoSuchElementException;
+
+/**
+ * Created by gcooney on 5/12/15.
+ */
+public class QueueFileTest extends AndroidTestCase {
+
+
+
+    public void notestParseQueueFile() throws IOException {
+        String fileName = "/Users/gcooney/Downloads/q1r1kn4a44_EOFException_number2";
+        File file = new File(fileName);
+        QueueFile queueFile = new QueueFile(file);
+        System.out.println(queueFile.size());
+    }
+
+    public void noprintQueueFile() throws IOException {
+        String fileName = "/Users/gcooney/Downloads/q1r1kn4a44_EOFException";
+        File file = new File(fileName);
+        FileInputStream fis = new FileInputStream(file);
+
+        int nextbyte = 0;
+        int counter = 0;
+        while (nextbyte >= 0) {
+            nextbyte = fis.read();
+
+            if (nextbyte >=0) {
+                System.out.print(nextbyte);
+                counter++;
+            }
+        }
+        System.out.println();
+        System.out.println("numBytes: " + counter);
+    }
+
+
+    public void notestQueueDequeue_oneThread() throws IOException {
+        QueueFile file = new QueueFile(new File("/usr/local/scbe/queuefile"));
+
+
+        QueueFile.ElementVisitor elementVisitor = new QueueFile.ElementVisitor() {
+            @Override
+            public boolean read(InputStream in, int length) throws IOException {
+                byte[] readBytes = new byte[length];
+                in.read(readBytes);
+
+                return true;
+            }
+        };
+
+        doModifyQueueFile(file);
+    }
+
+    public void testQueueDequeue_fiveThreads() throws IOException, InterruptedException {
+        Context context = new RenamingDelegatingContext(getContext(), "test_");
+        File folder = context.getDir("test-segment-disk-queue", Context.MODE_PRIVATE);
+        File theFile = new File(folder, "test-queue-file");
+        final QueueFile file = new QueueFile(theFile);
+
+
+        QueueFile.ElementVisitor elementVisitor = new QueueFile.ElementVisitor() {
+            @Override
+            public boolean read(InputStream in, int length) throws IOException {
+                byte[] readBytes = new byte[length];
+                in.read(readBytes);
+
+                return true;
+            }
+        };
+        Thread[] threads = new Thread[7];
+        for (int i = 0; i<threads.length; i++) {
+            Runnable toRun = new Runnable() {
+                @Override
+                public void run() {
+
+                    try {
+                        doModifyQueueFile(file);
+                    } catch (IOException e) {
+                        System.err.println("IOException: "+ e.getMessage());
+                        System.err.println(getStackTraceAsString(e));
+                    } catch(Throwable t) {
+                        System.err.println("Throwable: " + t.getMessage());
+                        System.err.println(getStackTraceAsString(t));
+                    }
+                }
+            };
+            threads[i] = new Thread(toRun);
+            threads[i].start();
+        }
+
+        for (int i = 0; i<threads.length; i++) {
+            threads[i].join(15 * 60 * 1000);
+        }
+    }
+
+    private void doModifyQueueFile(QueueFile file) throws IOException {
+        for (int i = 0; i < 500; i++) {
+            file.add(generateRandomBytes((int)(5000 * Math.random()) + 1));
+        }
+
+        for (int i = 0; i < Integer.MAX_VALUE; i++) {
+            double randChoice = Math.random();
+            if (randChoice < 0.951 || file.size() == 0) {
+                file.add(generateRandomBytes((int)(5000 * Math.random()) + 1));
+            } else {
+                int toRemove = (int) (50 * Math.random());
+                if (toRemove > file.size()) {
+                    toRemove = file.size();
+                }
+                try {
+                    file.remove(toRemove);
+                } catch(NoSuchElementException nse) {
+                    System.out.println("NoSuchElementException: "+nse.getMessage());
+                    System.out.println(getStackTraceAsString(nse));
+                }
+            }
+
+//            file.forEach(elementVisitor);
+        }
+    }
+
+
+    private byte[] generateRandomBytes(int length) {
+        byte[] myBytes = new byte[length];
+        for (int i=0; i<myBytes.length; i++) {
+            myBytes[i] = (byte)  (Math.random() * 256);
+        }
+
+        return myBytes;
+    }
+
+    private static String getStackTraceAsString(Throwable aThrowable) {
+        Writer result = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(result);
+        aThrowable.printStackTrace(printWriter);
+        return result.toString();
+    }
+
+}


### PR DESCRIPTION
I forked again this morning (May 21st) and just added the tests and am able to reproduce the issue using the same instructions as before  (Turn off Wifi / Network, run test, it's fine, Turn on Wifi, run test, get Exception)

```
05-21 11:37:39.965    4615-4641/com.segment.analytics.core.test E/Segment﹕ Payloads were rejected by server. Marked for removal.
    com.segment.analytics.Client$UploadException: HTTP 400: Bad Request. Response: Could not read response body for rejected message: java.io.FileNotFoundException: https://api.segment.io/v1/import
            at com.segment.analytics.Client$1.close(Client.java:58)
            at com.segment.analytics.SegmentDispatcher.performFlush(SegmentDispatcher.java:290)
            at com.segment.analytics.SegmentDispatcher.performFlush(SegmentDispatcher.java:325)
            at com.segment.analytics.SegmentDispatcher.access$100(SegmentDispatcher.java:44)
            at com.segment.analytics.SegmentDispatcher$2.run(SegmentDispatcher.java:251)
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:390)
            at java.util.concurrent.FutureTask.run(FutureTask.java:234)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
            at java.lang.Thread.run(Thread.java:841)
            at com.segment.analytics.internal.Utils$AnalyticsThread.run(Utils.java:284)
05-21 11:37:40.175    4615-4637/com.segment.analytics.core.test E/Segment﹕ Error while uploading payloads
    java.io.EOFException
            at java.io.RandomAccessFile.readFully(RandomAccessFile.java:419)
            at com.segment.analytics.QueueFile.ringRead(QueueFile.java:255)
            at com.segment.analytics.QueueFile.readElement(QueueFile.java:176)
            at com.segment.analytics.QueueFile.forEach(QueueFile.java:422)
            at com.segment.analytics.SegmentDispatcher.performFlush(SegmentDispatcher.java:283)
            at com.segment.analytics.SegmentDispatcher.performFlush(SegmentDispatcher.java:325)
            at com.segment.analytics.SegmentDispatcher.access$100(SegmentDispatcher.java:44)
            at com.segment.analytics.SegmentDispatcher$2.run(SegmentDispatcher.java:251)
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:390)
            at java.util.concurrent.FutureTask.run(FutureTask.java:234)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
            at java.lang.Thread.run(Thread.java:841)
            at com.segment.analytics.internal.Utils$AnalyticsThread.run(Utils.java:284)
05-21 11:37:45.400      698-786/? D/PackageManager﹕ Sending to user 0: act=android.intent.action.PACKAGE_CHANGED dat=package:com.google.android.gms flg=0x8000000 Bundle[{android.intent.extra.DONT_KILL_APP=true, android.intent.extra.user_handle=0, android.intent.extra.changed_component_name_list=[Ljava.lang.String;@45c2fd20, android.intent.extra.UID=10060, android.intent.extra.changed_component_name=com.google.android.gms.checkin.CheckinService$ActiveReceiver}]
    java.lang.RuntimeException: It's not exception, just print call stack
            at com.android.server.pm.PackageManagerService.sendPackageBroadcast(PackageManagerService.java:7681)
            at com.android.server.pm.PackageManagerService.sendPackageChangedBroadcast(PackageManagerService.java:12493)
            at com.android.server.pm.PackageManagerService.access$300(PackageManagerService.java:224)
            at com.android.server.pm.PackageManagerService$PackageHandler.doHandleMessage(PackageManagerService.java:921)
            at com.android.server.pm.PackageManagerService$PackageHandler.handleMessage(PackageManagerService.java:721)
            at android.os.Handler.dispatchMessage(Handler.java:99)
            at android.os.Looper.loop(Looper.java:137)
            at android.os.HandlerThread.run(HandlerThread.java:61)
05-21 11:37:46.351    4743-4743/? W/System.err﹕ android.content.pm.PackageManager$NameNotFoundException: com.sec.android.cloudagent
05-21 11:38:07.351    4615-4637/com.segment.analytics.core.test E/Segment﹕ Error while uploading payloads
    java.io.EOFException
            at java.io.RandomAccessFile.readFully(RandomAccessFile.java:419)
            at com.segment.analytics.QueueFile.ringRead(QueueFile.java:255)
            at com.segment.analytics.QueueFile.readElement(QueueFile.java:176)
            at com.segment.analytics.QueueFile.forEach(QueueFile.java:422)
            at com.segment.analytics.SegmentDispatcher.performFlush(SegmentDispatcher.java:283)
            at com.segment.analytics.SegmentDispatcher.access$100(SegmentDispatcher.java:44)
            at com.segment.analytics.SegmentDispatcher$2.run(SegmentDispatcher.java:251)
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:390)
            at java.util.concurrent.FutureTask.run(FutureTask.java:234)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
            at java.lang.Thread.run(Thread.java:841)
            at com.segment.analytics.internal.Utils$AnalyticsThread.run(Utils.java:284)
05-21 11:38:37.391    4615-4637/com.segment.analytics.core.test E/Segment﹕ Error while uploading payloads
    java.io.EOFException
            at java.io.RandomAccessFile.readFully(RandomAccessFile.java:419)
            at com.segment.analytics.QueueFile.ringRead(QueueFile.java:255)
            at com.segment.analytics.QueueFile.readElement(QueueFile.java:176)
            at com.segment.analytics.QueueFile.forEach(QueueFile.java:422)
            at com.segment.analytics.SegmentDispatcher.performFlush(SegmentDispatcher.java:283)
            at com.segment.analytics.SegmentDispatcher.access$100(SegmentDispatcher.java:44)
            at com.segment.analytics.SegmentDispatcher$2.run(SegmentDispatcher.java:251)
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:390)
            at java.util.concurrent.FutureTask.run(FutureTask.java:234)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1080)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:573)
            at java.lang.Thread.run(Thread.java:841)
            at com.segment.analytics.internal.Utils$AnalyticsThread.run(Utils.java:284)

```