### PR TITLE
fixing BundledIntegration Localytics closes #305

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Analytics.java
@@ -512,7 +512,7 @@ public class Analytics {
     GOOGLE_ANALYTICS("Google Analytics"),
     KAHUNA("Kahuna"),
     LEANPLUM("Leanplum"),
-    LOCALYTICS("Leanplum"),
+    LOCALYTICS("Localytics"),
     MIXPANEL("Mixpanel"),
     QUANTCAST("Quantcast"),
     TAPLYTICS("Taplytics"),


### PR DESCRIPTION
The Analytics.java BundledIntegration public enum had "Leanplum" inside LOCALYTICS. This PR fixes that.