### PR TITLE
Add support for incrementing customer value in Localytics

### DIFF
--- a/analytics-integrations/localytics/src/main/java/com/segment/analytics/internal/integrations/LocalyticsIntegration.java
+++ b/analytics-integrations/localytics/src/main/java/com/segment/analytics/internal/integrations/LocalyticsIntegration.java
@@ -128,7 +128,14 @@ public class LocalyticsIntegration extends AbstractIntegration<Void> {
     super.track(track);
     Properties props = track.properties();
     setContext(track.context());
-    Localytics.tagEvent(track.event(), props.toStringMap());
+    // Convert revenue to cents.
+    // http://docs.localytics.com/index.html#Dev/Instrument/customer-ltv.html
+    final long revenue = (long) (props.revenue() * 100);
+    if (revenue != 0) {
+      Localytics.tagEvent(track.event(), props.toStringMap(), revenue);
+    } else {
+      Localytics.tagEvent(track.event(), props.toStringMap());
+    }
     setCustomDimensions(props);
   }
 

--- a/analytics-integrations/localytics/src/test/java/com/segment/analytics/internal/integrations/LocalyticsTest.java
+++ b/analytics-integrations/localytics/src/test/java/com/segment/analytics/internal/integrations/LocalyticsTest.java
@@ -259,6 +259,13 @@ public class LocalyticsTest {
     Localytics.tagEvent("foo", new HashMap<String, String>());
   }
 
+  @Test public void trackWithRevenue() {
+    Properties props = new Properties().putRevenue(20);
+    integration.track(new TrackPayloadBuilder().event("bar").properties(props).build());
+    verifyStatic();
+    Localytics.tagEvent("bar", props.toStringMap(), 2000);
+  }
+
   @Test public void trackWithCustomDimensions() {
     integration.customDimensions = new ValueMap().putValue("foo", 9);
 


### PR DESCRIPTION
not sure if this is the correct way of handling just yet... but this is a first crack at adding support for customer LTV in localytics, a la: http://docs.localytics.com/index.html#Dev/Instrument/customer-ltv.html

iOS parity, for reference: https://github.com/segmentio/analytics-ios/blob/master/Analytics/Integrations/Localytics/SEGLocalyticsIntegration.m#L127-L134