### PR TITLE
Speed up Circle CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ clean:
 	@./gradlew clean
 
 test:
-	@./gradlew test
+	@./gradlew check test
 
 build:
 	@./gradlew build

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,7 @@ general:
   artifacts:
     - analytics-core/build/test-report
     - analytics-integrations/*/build/test-report
+    - build/reports/profile
 
 machine:
   environment:
@@ -11,16 +12,13 @@ machine:
 
 dependencies:
   cache_directories:
-#    - ~/.android
-#    - ~/android
     - ~/.gradle
   override:
-    - echo y | android update sdk -u -a -t build-tools-21.1.1
-    - TERM=dumb ./gradlew dependencies
+    - TERM=dumb ./gradlew dependencies --profile
 
 test:
   override:
-    - TERM=dumb ./gradlew build
+    - TERM=dumb ./gradlew assembleRelease checkRelease testRelease --profile
 
 deployment:
   snapshots:

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,3 @@ POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=segmentio
 POM_DEVELOPER_NAME=Segment, Inc.
-
-org.gradle.jvmargs=-Xmx2048m


### PR DESCRIPTION
* Use default build tools that come installed with Circle
* Build only the release variants

I've left profiling in since it doesn't seem to have much of an impact and would be useful to keep around. https://cloudup.com/cRdTOfRFcaK