### PR TITLE
Adds ability to set an initial capacity for Properties

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/Properties.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Properties.java
@@ -63,6 +63,10 @@ public class Properties extends ValueMap {
   public Properties() {
   }
 
+  public Properties(int initialCapacity) {
+    super(initialCapacity);
+  }
+
   // For deserialization
   Properties(Map<String, Object> delegate) {
     super(delegate);

--- a/analytics-core/src/main/java/com/segment/analytics/Traits.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Traits.java
@@ -91,6 +91,10 @@ public class Traits extends ValueMap {
   public Traits() {
   }
 
+  public Traits(int initialCapacity) {
+    super(initialCapacity);
+  }
+
   public Traits unmodifiableCopy() {
     LinkedHashMap<String, Object> map = new LinkedHashMap<>(this);
     return new Traits(unmodifiableMap(map));

--- a/analytics-core/src/main/java/com/segment/analytics/ValueMap.java
+++ b/analytics-core/src/main/java/com/segment/analytics/ValueMap.java
@@ -51,6 +51,10 @@ public class ValueMap implements Map<String, Object> {
     delegate = new LinkedHashMap<>();
   }
 
+  public ValueMap(int initialCapacity) {
+    delegate = new LinkedHashMap<>(initialCapacity);
+  }
+
   public ValueMap(Map<String, Object> map) {
     if (map == null) {
       throw new IllegalArgumentException("Map must not be null.");


### PR DESCRIPTION
Setting initial capacity sets the initial capacity of the delegated Map. This saves on unnecessary allocation when the map has a consistent size, which is common for tracking `Properties`.