### PR TITLE
Removes enum types in favor of StringDef and IntDef constants

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ First, you need to write your integration. You can copy the template in the `con
 
 Then you'll need to update our SDKs to know about the new integration.
 
-1. Update `Analytics.BundledIntegration` in [`analytics-core/src/main/java/com/segment/analytics/Analytics.java`](https://github.com/segmentio/analytics-android/blob/master/analytics-core/src/main/java/com/segment/analytics/Analytics.java) and add `MYTOOL("MyTool")` as an enum.
+1. Update `Analytics.BundledIntegration` in [`analytics-core/src/main/java/com/segment/analytics/Analytics.java`](https://github.com/segmentio/analytics-android/blob/master/analytics-core/src/main/java/com/segment/analytics/Analytics.java) and add `MYTOOL("MyTool")` as an BundledIntegration constant.
 2. Update [`IntegrationManager`](https://github.com/segmentio/analytics-android/blob/master/analytics-core/src/main/java/com/segment/analytics/IntegrationManager.java) and add `loadIntegration("com.segment.analytics.internal.integrations.MyToolIntegration");` to the `loadIntegrations()` method.
 3. Update [`settings.gradle`](https://github.com/segmentio/analytics-android/blob/master/settings.gradle) to pick up your integration.
 4. Update [our master project](https://github.com/segmentio/analytics-android/blob/master/analytics/build.gradle) and add your integration as a dependency.

--- a/analytics-core/build.gradle
+++ b/analytics-core/build.gradle
@@ -6,3 +6,7 @@ apply from: rootProject.file('gradle/checkstyle-library.gradle')
 apply from: rootProject.file('gradle/attach-jar.gradle')
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')
 
+dependencies {
+    provided "com.android.support:support-annotations:22.2.0"
+}
+

--- a/analytics-core/src/main/java/com/segment/analytics/Options.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Options.java
@@ -68,25 +68,11 @@ public class Options {
    * @param enabled <code>true</code> for enabled, <code>false</code> for disabled
    * @return This options object for chaining
    */
-  public Options setIntegration(String integrationKey, boolean enabled) {
+  public Options setIntegration(@Analytics.BundledIntegration String integrationKey, boolean enabled) {
     if (SegmentDispatcher.SEGMENT_KEY.equals(integrationKey)) {
       throw new IllegalArgumentException("Segment integration cannot be enabled or disabled.");
     }
     integrations.put(integrationKey, enabled);
-    return this;
-  }
-
-  /**
-   * Sets whether an action will be sent to the target integration. Same as {@link
-   * #setIntegration(String, boolean)} but type safe for bundled integrations.
-   *
-   * @param bundledIntegration The target integration
-   * @param enabled <code>true</code> for enabled, <code>false</code> for disabled
-   * @return This options object for chaining
-   * @see {@link Options#setIntegration(String, boolean)}
-   */
-  public Options setIntegration(Analytics.BundledIntegration bundledIntegration, boolean enabled) {
-    setIntegration(bundledIntegration.key, enabled);
     return this;
   }
 
@@ -97,22 +83,8 @@ public class Options {
    * @param options A map of data that will be used by the integration
    * @return This options object for chaining
    */
-  public Options setIntegrationOptions(String integrationKey, Map<String, Object> options) {
+  public Options setIntegrationOptions(@Analytics.BundledIntegration String integrationKey, Map<String, Object> options) {
     integrations.put(integrationKey, options);
-    return this;
-  }
-
-  /**
-   * Attach some integration specific options for this call. Same as
-   * {@link #setIntegrationOptions(String, Map)} but type safe for bundled integrations.
-   *
-   * @param bundledIntegration The target integration
-   * @param options A map of data that will be used by the integration
-   * @return This options object for chaining
-   */
-  public Options setIntegrationOptions(Analytics.BundledIntegration bundledIntegration,
-      Map<String, Object> options) {
-    integrations.put(bundledIntegration.key, options);
     return this;
   }
 

--- a/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/AliasPayload.java
+++ b/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/AliasPayload.java
@@ -36,7 +36,7 @@ public class AliasPayload extends BasePayload {
   private static final String PREVIOUS_ID_KEY = "previousId";
 
   public AliasPayload(AnalyticsContext context, Options options, String newId) {
-    super(Type.alias, context, options);
+    super(TYPE_ALIAS, context, options);
     put(USER_ID_KEY, newId);
     put(PREVIOUS_ID_KEY, context().traits().currentId());
   }

--- a/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/GroupPayload.java
+++ b/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/GroupPayload.java
@@ -44,7 +44,7 @@ public class GroupPayload extends BasePayload {
 
   public GroupPayload(AnalyticsContext context, Options options, String groupId,
       Traits groupTraits) {
-    super(Type.group, context, options);
+    super(TYPE_GROUP, context, options);
     put(GROUP_ID_KEY, groupId);
     put(TRAITS_KEY, groupTraits.unmodifiableCopy());
   }

--- a/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/IdentifyPayload.java
+++ b/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/IdentifyPayload.java
@@ -39,7 +39,7 @@ public class IdentifyPayload extends BasePayload {
   private static final String TRAITS_KEY = "traits";
 
   public IdentifyPayload(AnalyticsContext context, Options options, Traits traits) {
-    super(Type.identify, context, options);
+    super(TYPE_IDENTIFY, context, options);
     put(TRAITS_KEY, traits);
   }
 

--- a/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/ScreenPayload.java
+++ b/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/ScreenPayload.java
@@ -46,7 +46,7 @@ public class ScreenPayload extends BasePayload {
 
   public ScreenPayload(AnalyticsContext context, Options options, String category, String name,
       Properties properties) {
-    super(Type.screen, context, options);
+    super(TYPE_SCREEN, context, options);
     put(CATEGORY_KEY, category);
     put(NAME_KEY, name);
     put(PROPERTIES_KEY, properties);

--- a/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/TrackPayload.java
+++ b/analytics-core/src/main/java/com/segment/analytics/internal/model/payloads/TrackPayload.java
@@ -45,7 +45,7 @@ public class TrackPayload extends BasePayload {
 
   public TrackPayload(AnalyticsContext context, Options options, String event,
       Properties properties) {
-    super(Type.track, context, options);
+    super(TYPE_TRACK, context, options);
     put(EVENT_KEY, event);
     put(PROPERTIES_KEY, properties);
   }

--- a/analytics-integrations/countly/src/main/java/com/segment/analytics/internal/integrations/CountlyIntegration.java
+++ b/analytics-integrations/countly/src/main/java/com/segment/analytics/internal/integrations/CountlyIntegration.java
@@ -29,7 +29,7 @@ public class CountlyIntegration extends AbstractIntegration<Countly> {
   @Override public void initialize(Analytics analytics, ValueMap settings)
       throws IllegalStateException {
     countly = Countly.sharedInstance();
-    LogLevel logLevel = analytics.getLogLevel();
+    @LogLevel.Severity int logLevel = analytics.getLogLevel();
     countly.setLoggingEnabled(logLevel == INFO || logLevel == VERBOSE);
     String serverUrl = settings.getString("serverUrl");
     String appKey = settings.getString("appKey");

--- a/analytics-integrations/flurry/src/main/java/com/segment/analytics/internal/integrations/FlurryIntegration.java
+++ b/analytics-integrations/flurry/src/main/java/com/segment/analytics/internal/integrations/FlurryIntegration.java
@@ -35,7 +35,7 @@ public class FlurryIntegration extends AbstractIntegration<Void> {
     int sessionContinueSeconds = settings.getInt("sessionContinueSeconds", 10) * 1000;
     boolean captureUncaughtExceptions = settings.getBoolean("captureUncaughtExceptions", false);
     boolean reportLocation = settings.getBoolean("reportLocation", true);
-    LogLevel logLevel = analytics.getLogLevel();
+    @LogLevel.Severity int logLevel = analytics.getLogLevel();
 
     FlurryAgent.setContinueSessionMillis(sessionContinueSeconds);
     FlurryAgent.setCaptureUncaughtExceptions(captureUncaughtExceptions);

--- a/analytics-integrations/google-analytics/src/main/java/com/segment/analytics/internal/integrations/GoogleAnalyticsIntegration.java
+++ b/analytics-integrations/google-analytics/src/main/java/com/segment/analytics/internal/integrations/GoogleAnalyticsIntegration.java
@@ -58,7 +58,7 @@ public class GoogleAnalyticsIntegration extends AbstractIntegration<Tracker> {
     googleAnalyticsInstance = GoogleAnalytics.getInstance(context);
     tracker = googleAnalyticsInstance.newTracker(mobileTrackingId);
 
-    Analytics.LogLevel logLevel = analytics.getLogLevel();
+    @Analytics.LogLevel.Severity int logLevel = analytics.getLogLevel();
     if (logLevel == Analytics.LogLevel.INFO) {
       googleAnalyticsInstance.getLogger().setLogLevel(Logger.LogLevel.INFO);
     } else if (logLevel == Analytics.LogLevel.VERBOSE) {

--- a/analytics-integrations/kahuna/src/main/java/com/segment/analytics/internal/integrations/KahunaIntegration.java
+++ b/analytics-integrations/kahuna/src/main/java/com/segment/analytics/internal/integrations/KahunaIntegration.java
@@ -70,7 +70,7 @@ public class KahunaIntegration extends AbstractIntegration<Void> {
     KahunaAnalytics.onAppCreate(analytics.getApplication(), settings.getString("apiKey"),
         settings.getString("pushSenderId"));
 
-    LogLevel logLevel = analytics.getLogLevel();
+    @LogLevel.Severity int logLevel = analytics.getLogLevel();
     KahunaAnalytics.setDebugMode(logLevel == INFO || logLevel == VERBOSE);
   }
 

--- a/analytics-integrations/localytics/src/main/java/com/segment/analytics/internal/integrations/LocalyticsIntegration.java
+++ b/analytics-integrations/localytics/src/main/java/com/segment/analytics/internal/integrations/LocalyticsIntegration.java
@@ -39,7 +39,7 @@ public class LocalyticsIntegration extends AbstractIntegration<Void> {
   @Override public void initialize(Analytics analytics, ValueMap settings)
       throws IllegalStateException {
     Localytics.integrate(analytics.getApplication(), settings.getString("appKey"));
-    LogLevel logLevel = analytics.getLogLevel();
+    @LogLevel.Severity int logLevel = analytics.getLogLevel();
     Localytics.setLoggingEnabled(logLevel == INFO || logLevel == VERBOSE);
     hasSupportLibOnClassPath = isOnClassPath("android.support.v4.app.FragmentActivity");
     customDimensions = settings.getValueMap("dimensions");

--- a/analytics-integrations/mixpanel/src/main/java/com/segment/analytics/internal/integrations/MixpanelIntegration.java
+++ b/analytics-integrations/mixpanel/src/main/java/com/segment/analytics/internal/integrations/MixpanelIntegration.java
@@ -42,7 +42,7 @@ public class MixpanelIntegration extends AbstractIntegration<MixpanelAPI> {
   boolean trackCategorizedPages;
   boolean trackNamedPages;
   String token;
-  LogLevel logLevel;
+  @LogLevel.Severity int logLevel;
   Set<String> increments;
 
   private static void registerSuperProperties(JSONObject jsonObject, Traits traits)
@@ -121,7 +121,7 @@ public class MixpanelIntegration extends AbstractIntegration<MixpanelAPI> {
     try {
       registerSuperProperties(traits, identify.traits());
     } catch (JSONException e) {
-      if (logLevel.log()) {
+      if (LogLevel.log(logLevel)) {
         debug("Could not add super properties to JSONObject for Mixpanel Integration");
       }
     }

--- a/analytics-integrations/quantcast/src/main/java/com/segment/analytics/internal/integrations/QuantcastIntegration.java
+++ b/analytics-integrations/quantcast/src/main/java/com/segment/analytics/internal/integrations/QuantcastIntegration.java
@@ -35,7 +35,7 @@ public class QuantcastIntegration extends AbstractIntegration<Void> {
       throw new IllegalStateException("ACCESS_NETWORK_STATE is required");
     }
     apiKey = settings.getString("apiKey");
-    LogLevel logLevel = analytics.getLogLevel();
+    @LogLevel.Severity int logLevel = analytics.getLogLevel();
     QuantcastClient.enableLogging(logLevel == INFO || logLevel == VERBOSE);
   }
 

--- a/analytics-integrations/tapstream/src/main/java/com/segment/analytics/internal/integrations/TapstreamIntegration.java
+++ b/analytics-integrations/tapstream/src/main/java/com/segment/analytics/internal/integrations/TapstreamIntegration.java
@@ -44,7 +44,7 @@ public class TapstreamIntegration extends AbstractIntegration<Tapstream> {
     trackCategorizedPages = settings.getBoolean("trackCategorizedPages", true);
     trackNamedPages = settings.getBoolean("trackNamedPages", true);
 
-    LogLevel logLevel = analytics.getLogLevel();
+    @LogLevel.Severity int logLevel = analytics.getLogLevel();
     if (logLevel == INFO || logLevel == VERBOSE) {
       Logging.setLogger(new Logger() {
         @Override public void log(int i, String s) {

--- a/analytics-wear/src/main/java/com/segment/analytics/WearPayload.java
+++ b/analytics-wear/src/main/java/com/segment/analytics/WearPayload.java
@@ -16,13 +16,17 @@ class WearPayload extends ValueMap {
     super(delegate);
   }
 
-  WearPayload(BasePayload.Type type, ValueMap payload) {
+  WearPayload(@BasePayload.Type int type, ValueMap payload) {
+    if (!BasePayload.verifyType(type)) {
+      throw new IllegalArgumentException(type + " is not a valid type value see BasePayload.Type");
+    }
     put(TYPE_KEY, type);
     put(PAYLOAD_KEY, payload);
   }
 
-  BasePayload.Type type() {
-    return getEnum(BasePayload.Type.class, TYPE_KEY);
+  @SuppressWarnings("ResourceType")
+  @BasePayload.Type int type() {
+    return getInt(TYPE_KEY, BasePayload.TYPE_TRACK);
   }
 
   <T extends ValueMap> T payload(Class<T> clazz) {


### PR DESCRIPTION
Using `@StringDef` and `@IntDef` still gives type safety without the memory overhead of `enum`s.