### PR TITLE
Incorporates Tracking Plan filtering to event logging

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/IntegrationManager.java
+++ b/analytics-core/src/main/java/com/segment/analytics/IntegrationManager.java
@@ -383,7 +383,7 @@ class IntegrationManager implements Application.ActivityLifecycleCallbacks {
   /** Runs the given operation on all bundled integrations. */
   void run(IntegrationOperation operation) {
     if (logLevel.log()) {
-      debug("Running %s on %s integrations.", operation, integrations.size());
+      debug("Running %s.", operation);
     }
     for (int i = 0; i < integrations.size(); i++) {
       AbstractIntegration integration = integrations.get(i);
@@ -391,7 +391,7 @@ class IntegrationManager implements Application.ActivityLifecycleCallbacks {
       operation.run(integration, projectSettingsCache.get());
       long endTime = System.nanoTime();
       long duration = TimeUnit.NANOSECONDS.toMillis(endTime - startTime);
-      if (logLevel.log()) {
+      if (logLevel.log() && operation.isEnabled(integration, projectSettingsCache.get())) {
         debug("Took %s ms to run action %s on %s.", duration, operation, integration.key());
       }
       stats.dispatchIntegrationOperation(integration.key(), duration);

--- a/analytics-core/src/main/java/com/segment/analytics/IntegrationOperation.java
+++ b/analytics-core/src/main/java/com/segment/analytics/IntegrationOperation.java
@@ -9,6 +9,8 @@ import com.segment.analytics.internal.model.payloads.IdentifyPayload;
 import com.segment.analytics.internal.model.payloads.ScreenPayload;
 import com.segment.analytics.internal.model.payloads.TrackPayload;
 
+import java.util.List;
+
 import static com.segment.analytics.Options.ALL_INTEGRATIONS_KEY;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
@@ -154,6 +156,13 @@ abstract class IntegrationOperation {
   static IntegrationOperation track(final TrackPayload trackPayload) {
     return new IntegrationOperation() {
       @Override public void run(AbstractIntegration integration, ProjectSettings projectSettings) {
+        if (isEnabled(integration, projectSettings)) {
+          integration.track(trackPayload);
+        }
+      }
+
+      @Override
+      protected boolean isEnabled(AbstractIntegration integration, ProjectSettings projectSettings) {
         ValueMap trackingPlan = projectSettings.trackingPlan();
         boolean trackEnabled = true;
 
@@ -167,9 +176,7 @@ abstract class IntegrationOperation {
           }
         }
 
-        if (trackEnabled) {
-          integration.track(trackPayload);
-        }
+        return trackEnabled;
       }
 
       @Override public String toString() {
@@ -231,4 +238,8 @@ abstract class IntegrationOperation {
 
   /** Run this operation on the given integration. */
   abstract void run(AbstractIntegration integration, ProjectSettings projectSettings);
+
+  protected boolean isEnabled(AbstractIntegration integration, ProjectSettings projectSettings) {
+    return true;
+  }
 }


### PR DESCRIPTION
The logging currently doesn't properly convey when the event will be filtered from an integration, so it always shows are sending to all Bundled Integrations, even when it is not.