### PR TITLE
Log when Analytics client is created.

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Analytics.java
@@ -751,6 +751,10 @@ public class Analytics {
       AnalyticsContext analyticsContext = AnalyticsContext.create(application, traitsCache.get());
       analyticsContext.attachAdvertisingId(application);
 
+      if (logLevel.log()) {
+        debug("Creating analytics client for project with writeKey: %s.", writeKey);
+      }
+
       return new Analytics(application, networkExecutor, integrationManagerFactory, stats,
           traitsCache, analyticsContext, defaultOptions, logLevel);
     }


### PR DESCRIPTION
Users are often confused by seeing crashes like #309, casued by creating
multiple instances of the analytics client with the same write key that
share the same disk queue.

This logs each time you create an analytics instance and hopefully does
a better job of surfacing incorrect uses of our API.