### PR TITLE
Makes Properties a null-safe Map

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/Properties.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Properties.java
@@ -73,8 +73,14 @@ public class Properties extends ValueMap {
   }
 
   @Override public Properties putValue(String key, Object value) {
-    super.putValue(key, value);
+    if (value != null) {
+      super.putValue(key, value);
+    }
     return this;
+  }
+  
+  @Override public Object put(String key, Object value) {
+    return value != null ? super.put(key, value) : null;
   }
 
   /**


### PR DESCRIPTION
This prevents keys in the `Properties` from having null values. Which is an issue I ran into with the Mixpanel SDK and implemented in our code. Wanted to share it in case others could end up in the same problem.