### PR TITLE
Fix race condition during IntegrationManager initialization.

### DIFF
--- a/analytics-core/src/main/java/com/segment/analytics/IntegrationManager.java
+++ b/analytics-core/src/main/java/com/segment/analytics/IntegrationManager.java
@@ -93,8 +93,6 @@ class IntegrationManager implements Application.ActivityLifecycleCallbacks {
     this.projectSettingsCache = projectSettingsCache;
     this.logLevel = analytics.getLogLevel();
 
-    application.registerActivityLifecycleCallbacks(this);
-
     integrationManagerThread =
         new HandlerThread(INTEGRATION_MANAGER_THREAD_NAME, THREAD_PRIORITY_BACKGROUND);
     integrationManagerThread.start();
@@ -117,6 +115,7 @@ class IntegrationManager implements Application.ActivityLifecycleCallbacks {
     } else {
       dispatchFetchSettings();
     }
+    application.registerActivityLifecycleCallbacks(this);
   }
 
   private void loadIntegrations() {


### PR DESCRIPTION
This fixes a race condition when the `Analytics` client is initialized
off the main thread.

1) `Analytics` is initialized on a non-main thread.
2) `registerActivityLifecycleCallbacks` is called before the thread is
created.
3) `IntegrationManager` receives onActivityPaused from the main thread,
before integrationManagerHandler is initialized.

The fix defers calling `registerActivityLifecycleCallbacks` until the
handler is initialized.

This also initializes the `SegmentIntegration` and adds it to the list
first.

Closes #329.