### PR TITLE
Updating Amplitude SDK to v2.0.2

### DIFF
--- a/analytics-integrations/amplitude/build.gradle
+++ b/analytics-integrations/amplitude/build.gradle
@@ -1,5 +1,5 @@
 apply from: rootProject.file('gradle/integration.gradle')
 
 dependencies {
-  compile 'com.amplitude:android-sdk:1.7.0'
+  compile 'com.amplitude:android-sdk:2.0.2'
 }

--- a/analytics-integrations/amplitude/src/main/java/com/segment/analytics/internal/integrations/AmplitudeIntegration.java
+++ b/analytics-integrations/amplitude/src/main/java/com/segment/analytics/internal/integrations/AmplitudeIntegration.java
@@ -1,6 +1,5 @@
 package com.segment.analytics.internal.integrations;
 
-import android.app.Activity;
 import com.amplitude.api.AmplitudeClient;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
@@ -34,8 +33,13 @@ public class AmplitudeIntegration extends AbstractIntegration<Void> {
     trackAllPages = settings.getBoolean("trackAllPages", false);
     trackCategorizedPages = settings.getBoolean("trackCategorizedPages", false);
     trackNamedPages = settings.getBoolean("trackNamedPages", false);
+    boolean trackSessionEvents = settings.getBoolean("trackSessionEvents", false);
     amplitude = AmplitudeClient.getInstance();
     amplitude.initialize(analytics.getApplication(), settings.getString("apiKey"));
+    amplitude.enableForegroundTracking(analytics.getApplication());
+    if (trackSessionEvents) {
+      amplitude.trackSessionEvents(true);
+    }
   }
 
   @Override public Void getUnderlyingInstance() {
@@ -44,16 +48,6 @@ public class AmplitudeIntegration extends AbstractIntegration<Void> {
 
   @Override public String key() {
     return AMPLITUDE_KEY;
-  }
-
-  @Override public void onActivityResumed(Activity activity) {
-    super.onActivityResumed(activity);
-    amplitude.startSession();
-  }
-
-  @Override public void onActivityPaused(Activity activity) {
-    super.onActivityPaused(activity);
-    amplitude.endSession();
   }
 
   @Override public void identify(IdentifyPayload identify) {

--- a/analytics-integrations/amplitude/src/test/java/com/segment/analytics/internal/integrations/AmplitudeTest.java
+++ b/analytics-integrations/amplitude/src/test/java/com/segment/analytics/internal/integrations/AmplitudeTest.java
@@ -113,7 +113,7 @@ public class AmplitudeTest {
 
     integration.onActivityResumed(activity);
 
-    verify(amplitude).startSession();
+    verifyNoMoreInteractions(amplitude);
   }
 
   @Test public void activityPause() {
@@ -121,7 +121,7 @@ public class AmplitudeTest {
 
     integration.onActivityPaused(activity);
 
-    verify(amplitude).endSession();
+    verifyNoMoreInteractions(amplitude);
   }
 
   @Test public void activityStop() {


### PR DESCRIPTION
Updating Amplitude SDK to v2.0.2.

* API change - removed startSession() and endSession(). Sessions are now handled by attaching an ActivityLifecycleCallback (calling enableForeGroundTracking during init and passing in the Application). See Setup, bullet 4: https://github.com/amplitude/Amplitude-Android#setup
* Start/end session events are no longer logged by default; however, users can re-enable them by calling trackSessionEvents(true) on the Amplitude Client. This is exposed in Segment via the trackSessionEvents setting.