### PR TITLE
Embed integrations object into each message

### DIFF
--- a/analytics-core-tests/src/test/java/com/segment/analytics/BatchPayloadWriterTest.java
+++ b/analytics-core-tests/src/test/java/com/segment/analytics/BatchPayloadWriterTest.java
@@ -3,10 +3,7 @@ package com.segment.analytics;
 import com.segment.analytics.core.tests.BuildConfig;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -24,12 +21,7 @@ public class BatchPayloadWriterTest {
     SegmentDispatcher.BatchPayloadWriter batchPayloadWriter =
         new SegmentDispatcher.BatchPayloadWriter(byteArrayOutputStream);
 
-    final HashMap<String, Boolean> integrations = new LinkedHashMap<>();
-    integrations.put("foo", false);
-    integrations.put("bar", true);
-
     batchPayloadWriter.beginObject()
-        .integrations(integrations)
         .beginBatchArray()
         .emitPayloadObject("foobarbazqux")
         .emitPayloadObject("{}")
@@ -39,8 +31,7 @@ public class BatchPayloadWriterTest {
         .close();
 
     assertThat(byteArrayOutputStream.toString()) //
-        .overridingErrorMessage("It's OK if this failed close to midnight!")
-        .isEqualTo("{\"integrations\":{\"foo\":false,\"bar\":true},"
+        .isEqualTo("{"
             + "\"batch\":[foobarbazqux,{},2],"
             + "\"sentAt\":\""
             + toISO8601Date(new Date())
@@ -52,12 +43,7 @@ public class BatchPayloadWriterTest {
     SegmentDispatcher.BatchPayloadWriter batchPayloadWriter =
         new SegmentDispatcher.BatchPayloadWriter(byteArrayOutputStream);
 
-    final HashMap<String, Boolean> integrations = new LinkedHashMap<>();
-    integrations.put("foo", false);
-    integrations.put("bar", true);
-
     batchPayloadWriter.beginObject()
-        .integrations(integrations)
         .beginBatchArray()
         .emitPayloadObject("qaz")
         .endBatchArray()
@@ -65,26 +51,7 @@ public class BatchPayloadWriterTest {
         .close();
 
     assertThat(byteArrayOutputStream.toString()) //
-        .isEqualTo("{\"integrations\":{\"foo\":false,\"bar\":true},\"batch\":[qaz],\"sentAt\":\""
-            + toISO8601Date(new Date())
-            + "\"}").overridingErrorMessage("its ok if this failed close to midnight!");
-  }
-
-  @Test public void batchPayloadWriterNoIntegrations() throws IOException {
-    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    SegmentDispatcher.BatchPayloadWriter batchPayloadWriter =
-        new SegmentDispatcher.BatchPayloadWriter(byteArrayOutputStream);
-
-    batchPayloadWriter.beginObject()
-        .integrations(Collections.<String, Boolean>emptyMap())
-        .beginBatchArray()
-        .emitPayloadObject("foo")
-        .endBatchArray()
-        .endObject()
-        .close();
-
-    assertThat(byteArrayOutputStream.toString()) //
-        .isEqualTo("{\"batch\":[foo],\"sentAt\":\"" + toISO8601Date(new Date()) + "\"}")
+        .isEqualTo("{\"batch\":[qaz],\"sentAt\":\"" + toISO8601Date(new Date()) + "\"}")
         .overridingErrorMessage("its ok if this failed close to midnight!");
   }
 
@@ -93,17 +60,8 @@ public class BatchPayloadWriterTest {
     SegmentDispatcher.BatchPayloadWriter batchPayloadWriter =
         new SegmentDispatcher.BatchPayloadWriter(byteArrayOutputStream);
 
-    HashMap<String, Boolean> integrations = new LinkedHashMap<>();
-    integrations.put("foo", false);
-    integrations.put("bar", true);
-
     try {
-      batchPayloadWriter.beginObject()
-          .integrations(integrations)
-          .beginBatchArray()
-          .endBatchArray()
-          .endObject()
-          .close();
+      batchPayloadWriter.beginObject().beginBatchArray().endBatchArray().endObject().close();
     } catch (IOException exception) {
       assertThat(exception).hasMessage("At least one payload must be provided.");
     }

--- a/analytics-core/src/main/java/com/segment/analytics/SegmentDispatcher.java
+++ b/analytics-core/src/main/java/com/segment/analytics/SegmentDispatcher.java
@@ -196,6 +196,11 @@ class SegmentDispatcher extends AbstractIntegration {
   }
 
   void performEnqueue(BasePayload payload) {
+    // Override any user provided values with anything that was bundled.
+    // e.g. If user did Mixpanel: true and it was bundled, this would correctly override it with
+    // false so that the server doesn't send that event as well.
+    payload.integrations().putAll(bundledIntegrations);
+
     if (queueFile.size() >= MAX_QUEUE_SIZE) {
       synchronized (flushLock) {
         // Double checked locking, the network executor could have removed payload from the queue
@@ -276,9 +281,8 @@ class SegmentDispatcher extends AbstractIntegration {
         connection = client.upload();
 
         // Write the payloads into the OutputStream.
-        BatchPayloadWriter writer = new BatchPayloadWriter(connection.os).beginObject()
-            .integrations(bundledIntegrations)
-            .beginBatchArray();
+        BatchPayloadWriter writer =
+            new BatchPayloadWriter(connection.os).beginObject().beginBatchArray();
         PayloadWriter payloadWriter = new PayloadWriter(writer);
         queueFile.forEach(payloadWriter);
         writer.endBatchArray().endObject().close();
@@ -370,17 +374,6 @@ class SegmentDispatcher extends AbstractIntegration {
 
     BatchPayloadWriter beginObject() throws IOException {
       jsonWriter.beginObject();
-      return this;
-    }
-
-    BatchPayloadWriter integrations(Map<String, Boolean> integrations) throws IOException {
-      if (!isNullOrEmpty(integrations)) {
-        jsonWriter.name("integrations").beginObject();
-        for (Map.Entry<String, Boolean> entry : integrations.entrySet()) {
-          jsonWriter.name(entry.getKey()).value(entry.getValue());
-        }
-        jsonWriter.endObject();
-      }
       return this;
     }
 


### PR DESCRIPTION
This fixes a bug that would occur when an integration was bundled and
marked with `true`. The `true` would override the bundled `false` in the
integration object of the message, and would be sent server side, as
well as client side.

This updates the code so that we merge the two and save it to disk, at
the cost of increasing our payload sizes.

Also fixes an edge case that could occur when a bundled integration was
enabled after the message got enqueued. THis way the message object
holds the truth about the integration as of the time of creation, rather
than when it gets uploaded.