### PR TITLE
Add 'collectDeviceId' Builder option

### DIFF
--- a/analytics-core-tests/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics-core-tests/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -27,7 +27,7 @@ public class AnalyticsContextTest {
   }
 
   @Test public void create() {
-    analyticsContext = AnalyticsContext.create(RuntimeEnvironment.application, traits);
+    analyticsContext = AnalyticsContext.create(RuntimeEnvironment.application, traits, true);
     assertThat(analyticsContext) //
         .containsKey("app") //
         .containsKey("device") //

--- a/analytics-core-tests/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics-core-tests/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -66,6 +66,15 @@ public class AnalyticsContextTest {
         .containsEntry("density", 1.5f) //
         .containsEntry("width", 480) //
         .containsEntry("height", 800);
+
+    // disable device id collection
+    analyticsContext = AnalyticsContext.create(RuntimeEnvironment.application, traits, false);
+
+    assertThat(analyticsContext.getValueMap("device")) //
+        .containsEntry("id", traits.anonymousId())
+        .containsEntry("manufacturer", "unknown")
+        .containsEntry("model", "unknown")
+        .containsEntry("name", "unknown");
   }
 
   @Test public void copyReturnsSameMappings() {

--- a/analytics-core/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Analytics.java
@@ -579,6 +579,7 @@ public class Analytics {
 
     private final Application application;
     private String writeKey;
+    private boolean collectDeviceID = Utils.DEFAULT_COLLECT_DEVICE_ID;
     private int flushQueueSize = Utils.DEFAULT_FLUSH_QUEUE_SIZE;
     private long flushIntervalInMillis = Utils.DEFAULT_FLUSH_INTERVAL;
     private Options defaultOptions;
@@ -640,6 +641,18 @@ public class Analytics {
         throw new IllegalArgumentException("flushInterval must be greater than zero.");
       }
       this.flushIntervalInMillis = timeUnit.toMillis(flushInterval);
+      return this;
+    }
+
+    /**
+     * Enable or disable collection of {@link android.provider.Settings.Secure#ANDROID_ID},
+     * {@link android.os.Build#SERIAL} or the Telephony Identifier retreived via
+     * {@link TelephonyManager#getDeviceId()} as available.
+     *
+     * Collection of the device identifier is enabled by default.
+     */
+    public Builder collectDeviceId(boolean collect) {
+      this.collectDeviceID = collect;
       return this;
     }
 
@@ -759,7 +772,8 @@ public class Analytics {
         Traits traits = Traits.create();
         traitsCache.set(traits);
       }
-      AnalyticsContext analyticsContext = AnalyticsContext.create(application, traitsCache.get());
+      AnalyticsContext analyticsContext = AnalyticsContext.create(application, traitsCache.get(),
+              this.collectDeviceID);
       analyticsContext.attachAdvertisingId(application);
 
       synchronized (INSTANCES) {

--- a/analytics-core/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics-core/src/main/java/com/segment/analytics/Analytics.java
@@ -773,7 +773,7 @@ public class Analytics {
         traitsCache.set(traits);
       }
       AnalyticsContext analyticsContext = AnalyticsContext.create(application, traitsCache.get(),
-              this.collectDeviceID);
+              collectDeviceID);
       analyticsContext.attachAdvertisingId(application);
 
       synchronized (INSTANCES) {

--- a/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -124,7 +124,7 @@ public class AnalyticsContext extends ValueMap {
     analyticsContext.putDevice(context, collectDeviceId);
     analyticsContext.putLibrary();
     analyticsContext.put(LOCALE_KEY,
-            Locale.getDefault().getLanguage() + "-" + Locale.getDefault().getCountry());
+        Locale.getDefault().getLanguage() + "-" + Locale.getDefault().getCountry());
     analyticsContext.putNetwork(context);
     analyticsContext.putOs();
     analyticsContext.putScreen(context);

--- a/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -46,7 +46,6 @@ import static android.content.Context.TELEPHONY_SERVICE;
 import static android.net.ConnectivityManager.TYPE_BLUETOOTH;
 import static android.net.ConnectivityManager.TYPE_MOBILE;
 import static android.net.ConnectivityManager.TYPE_WIFI;
-import static com.segment.analytics.internal.Utils.DEFAULT_COLLECT_DEVICE_ID;
 import static com.segment.analytics.internal.Utils.NullableConcurrentHashMap;
 import static com.segment.analytics.internal.Utils.createMap;
 import static com.segment.analytics.internal.Utils.getDeviceId;

--- a/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics-core/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -134,16 +134,6 @@ public class AnalyticsContext extends ValueMap {
     return analyticsContext;
   }
 
-  /**
-   * Create a new {@link AnalyticsContext} instance filled in with information from the given
-   * {@link Context}. The {@link Analytics} client can be called from anywhere, so the returned
-   * instances is thread safe. This is a convenience wrapper for the method
-   * {@link #create(Context, Traits, boolean)}
-   */
-  static synchronized AnalyticsContext create(Context context, Traits traits) {
-    return create(context, traits, DEFAULT_COLLECT_DEVICE_ID);
-  }
-
   static void putUndefinedIfNull(Map<String, Object> target, String key, CharSequence value) {
     if (isNullOrEmpty(value)) {
       target.put(key, "undefined");

--- a/analytics-core/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics-core/src/main/java/com/segment/analytics/internal/Utils.java
@@ -73,6 +73,7 @@ public final class Utils {
   public static final String THREAD_PREFIX = "SegmentAnalytics-";
   public static final int DEFAULT_FLUSH_INTERVAL = 30 * 1000; // 30s
   public static final int DEFAULT_FLUSH_QUEUE_SIZE = 20;
+  public static final boolean DEFAULT_COLLECT_DEVICE_ID = true;
   final static String TAG = "Segment";
   @SuppressLint("SimpleDateFormat") private static final DateFormat ISO_8601_DATE_FORMAT =
       new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");


### PR DESCRIPTION
This PR adds an option to the `Builder`, `collectDeviceId`.

If the option is disabled, the `device:id` property of the device json object will use the `anonymousId` in place of the device identifier. This option is enabled by default.

Some terms-of-service do not allow this type of collection to take place, so it helps our adoption of Segment knowing we can disable it.