### PR TITLE
updating Amplitude SDK to v2.1.0

### DIFF
--- a/analytics-integrations/amplitude/build.gradle
+++ b/analytics-integrations/amplitude/build.gradle
@@ -1,5 +1,5 @@
 apply from: rootProject.file('gradle/integration.gradle')
 
 dependencies {
-  compile 'com.amplitude:android-sdk:2.0.4'
+  compile 'com.amplitude:android-sdk:2.1.0'
 }


### PR DESCRIPTION
A bug fix and added support for user property operations: https://github.com/amplitude/Amplitude-Android/releases/tag/v2.1.0.

The underlying implementation for setUserProperties now uses our identify api, but the Segment Identify call should still work as intended. 