### PR TITLE
Changed Localytics LogLevel Trigger

### DIFF
--- a/analytics-integrations/localytics/src/main/java/com/segment/analytics/internal/integrations/LocalyticsIntegration.java
+++ b/analytics-integrations/localytics/src/main/java/com/segment/analytics/internal/integrations/LocalyticsIntegration.java
@@ -42,7 +42,7 @@ public class LocalyticsIntegration extends AbstractIntegration<Void> {
       throws IllegalStateException {
     log = analytics.getLogger().newLogger(LOCALYTICS_KEY);
 
-    boolean loggingEnabled = log.logLevel.ordinal() >= LogLevel.DEBUG.ordinal();
+    boolean loggingEnabled = log.logLevel.ordinal() >= LogLevel.VERBOSE.ordinal();
     Localytics.setLoggingEnabled(loggingEnabled);
     log.verbose("Localytics.setLoggingEnabled(%s);", loggingEnabled);
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.segment.analytics.android
 
-VERSION_CODE=340
-VERSION_NAME=3.4.0
+VERSION_CODE=341
+VERSION_NAME=3.4.1-SNAPSHOT
 
 POM_NAME=Segment for Android
 POM_DESCRIPTION=The hassle-free way to add analytics to your Android app.

--- a/release.version
+++ b/release.version
@@ -2,4 +2,5 @@
   release.version -- Version Information for unknown (syntax: Text)
   [automatically generated and maintained by GNU shtool]
 
-  This is unknown, Version 3.4.0 (10-Oct-2015)
+  This is unknown, Version 3.4.1 (20-Oct-2015)
+


### PR DESCRIPTION
Localytics internal logging outputs at verbose level. It makes sense for us to do the same from Segment to trigger that. Seen as Localytics is really verbose this probably favours most implementations too.