### PR TITLE
Fix disabling bundled integrations server side.

### DIFF
--- a/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -215,6 +215,10 @@ public class AnalyticsTest {
     }
   }
 
+  @Test public void bundle() {
+    assertThat(analytics.bundledIntegrations).contains(MapEntry.entry("test", false));
+  }
+
   @Test public void screen() {
     analytics.screen("android", "saw tests", new Properties().putUrl("github.com"));
     verify(integration).screen(argThat(new NoDescriptionMatcher<ScreenPayload>() {

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -1011,7 +1011,7 @@ public class Analytics {
         logger.info("Factory %s couldn't create integration.", factory);
       } else {
         integrations.put(key, integration);
-        bundledIntegrations.put(key, true);
+        bundledIntegrations.put(key, false);
       }
     }
     factories = null;


### PR DESCRIPTION
Previously we were setting `integration: true` for bundled integrations.
This would cause it to be processed client and server side. This commit
fixes the behaviour and adds a test case.