### PR TITLE
Refactor Options handling

### DIFF
--- a/analytics-tests/src/test/java/com/segment/analytics/TestUtils.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/TestUtils.java
@@ -70,7 +70,7 @@ public final class TestUtils {
         + "\"anonymousId\":null,"
         + "\"timestamp\":\"2014-12-15T13:32:44-0700\","
         + "\"integrations\":"
-        + "{\"All\":true},"
+        + "{},"
         + "\"event\":\"foo\","
         + "\"properties\":{}"
         + "}";

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -106,7 +106,7 @@ public class Analytics {
   final Client client;
   final Cartographer cartographer;
   private final ProjectSettings.Cache projectSettingsCache;
-  private ProjectSettings projectSettings;
+  ProjectSettings projectSettings; // todo: make final (non-final for testing).
   private final String writeKey;
   final int flushQueueSize;
   final long flushIntervalInMillis;

--- a/analytics/src/main/java/com/segment/analytics/Options.java
+++ b/analytics/src/main/java/com/segment/analytics/Options.java
@@ -45,7 +45,6 @@ public class Options {
 
   public Options() {
     integrations = new ConcurrentHashMap<>();
-    integrations.put(ALL_INTEGRATIONS_KEY, true);
   }
 
   /**


### PR DESCRIPTION
Previously if you sent `All: false`, we'd only use the tracking plan to
figure out if the track event should be sent to integrations.

This updates is so that the Options object takes precedence over all
else. The event tracking plan cannot override options and only fill in
missing pieces.