### PR TITLE
Fix logic for collecting isLimitAdTracking

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -116,7 +116,7 @@ public class AnalyticsContext extends ValueMap {
    * instances is thread safe.
    */
   static synchronized AnalyticsContext create(Context context, Traits traits,
-                                              boolean collectDeviceId) {
+      boolean collectDeviceId) {
     AnalyticsContext analyticsContext =
         new AnalyticsContext(new NullableConcurrentHashMap<String, Object>());
     analyticsContext.putApp(context);
@@ -410,7 +410,9 @@ public class AnalyticsContext extends ValueMap {
 
     /** Set the advertising information for this device. */
     void putAdvertisingInfo(String advertisingId, boolean adTrackingEnabled) {
-      put(DEVICE_ADVERTISING_ID_KEY, advertisingId);
+      if (adTrackingEnabled && !isNullOrEmpty(advertisingId)) {
+        put(DEVICE_ADVERTISING_ID_KEY, advertisingId);
+      }
       put(DEVICE_AD_TRACKING_ENABLED_KEY, adTrackingEnabled);
     }
 

--- a/analytics/src/main/java/com/segment/analytics/GetAdvertisingIdTask.java
+++ b/analytics/src/main/java/com/segment/analytics/GetAdvertisingIdTask.java
@@ -26,8 +26,14 @@ class GetAdvertisingIdTask extends AsyncTask<Context, Void, Pair<String, Boolean
       Boolean isLimitAdTrackingEnabled = (Boolean) advertisingInfo.getClass()
           .getMethod("isLimitAdTrackingEnabled")
           .invoke(advertisingInfo);
-      String id = (String) advertisingInfo.getClass().getMethod("getId").invoke(advertisingInfo);
-      return Pair.create(id, isLimitAdTrackingEnabled);
+
+      if (isLimitAdTrackingEnabled) {
+        return Pair.create(null, false);
+      }
+
+      String advertisingId =
+          (String) advertisingInfo.getClass().getMethod("getId").invoke(advertisingInfo);
+      return Pair.create(advertisingId, true);
     } catch (Exception ignored) {
       return null;
     }
@@ -35,11 +41,13 @@ class GetAdvertisingIdTask extends AsyncTask<Context, Void, Pair<String, Boolean
 
   @Override protected void onPostExecute(Pair<String, Boolean> info) {
     super.onPostExecute(info);
-    if (info != null) {
-      AnalyticsContext.Device device = analyticsContext.device();
-      if (device != null) {
-        device.putAdvertisingInfo(info.first, info.second);
-      }
+    if (info == null) {
+      return;
+    }
+
+    AnalyticsContext.Device device = analyticsContext.device();
+    if (device != null) {
+      device.putAdvertisingInfo(info.first, info.second);
     }
   }
 }


### PR DESCRIPTION
Previously we were simply copying over isLimitAdTracking to
adTrackingEnabled. These fields are the inverse of each other, so this
commit fixes the logic and makes it so that adTrackingEnabled is
recorded as !isLimitAdTracking.

Also completely stop recording advertisingId if adTrackingEnabled is false.