### PR TITLE
Wait for advertising ID to be populated before enqueing events.

### DIFF
--- a/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -18,6 +18,7 @@ import com.segment.analytics.integrations.TrackPayload;
 import com.segment.analytics.internal.Utils.AnalyticsNetworkExecutorService;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import org.assertj.core.data.MapEntry;
 import org.hamcrest.Description;
@@ -110,7 +111,7 @@ public class AnalyticsTest {
     analytics = new Analytics(application, networkExecutor, stats, traitsCache, analyticsContext,
         defaultOptions, Logger.with(NONE), "qaz", Collections.singletonList(factory), client,
         Cartographer.INSTANCE, projectSettingsCache, "foo", DEFAULT_FLUSH_QUEUE_SIZE,
-        DEFAULT_FLUSH_INTERVAL, analyticsExecutor, false);
+        DEFAULT_FLUSH_INTERVAL, analyticsExecutor, false, new CountDownLatch(0));
 
     // Used by singleton tests.
     grantPermission(RuntimeEnvironment.application, Manifest.permission.INTERNET);
@@ -563,7 +564,7 @@ public class AnalyticsTest {
     analytics = new Analytics(application, networkExecutor, stats, traitsCache, analyticsContext,
         defaultOptions, Logger.with(NONE), "qaz", Collections.singletonList(factory), client,
         Cartographer.INSTANCE, projectSettingsCache, "foo", DEFAULT_FLUSH_QUEUE_SIZE,
-        DEFAULT_FLUSH_INTERVAL, analyticsExecutor, true);
+        DEFAULT_FLUSH_INTERVAL, analyticsExecutor, true, new CountDownLatch(0));
 
     verify(integration).track(argThat(new NoDescriptionMatcher<TrackPayload>() {
       @Override protected boolean matchesSafely(TrackPayload payload) {
@@ -603,7 +604,7 @@ public class AnalyticsTest {
     analytics = new Analytics(application, networkExecutor, stats, traitsCache, analyticsContext,
         defaultOptions, Logger.with(NONE), "qaz", Collections.singletonList(factory), client,
         Cartographer.INSTANCE, projectSettingsCache, "foo", DEFAULT_FLUSH_QUEUE_SIZE,
-        DEFAULT_FLUSH_INTERVAL, analyticsExecutor, true);
+        DEFAULT_FLUSH_INTERVAL, analyticsExecutor, true, new CountDownLatch(0));
 
     verify(integration).track(argThat(new NoDescriptionMatcher<TrackPayload>() {
       @Override protected boolean matchesSafely(TrackPayload payload) {

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -39,6 +39,7 @@ import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.concurrent.CountDownLatch;
 
 import static android.Manifest.permission.ACCESS_NETWORK_STATE;
 import static android.content.Context.CONNECTIVITY_SERVICE;
@@ -146,12 +147,14 @@ public class AnalyticsContext extends ValueMap {
     super(delegate);
   }
 
-  void attachAdvertisingId(Context context) {
+  void attachAdvertisingId(Context context, CountDownLatch latch) {
     // This is done as an extra step so we don't run into errors like this for testing
     // http://pastebin.com/gyWJKWiu
     if (isOnClassPath("com.google.android.gms.ads.identifier.AdvertisingIdClient")) {
       // this needs to be done each time since the settings may have been updated
-      new GetAdvertisingIdTask(this).execute(context);
+      new GetAdvertisingIdTask(this, latch).execute(context);
+    } else {
+      latch.countDown();
     }
   }
 


### PR DESCRIPTION
Retrieving the advertising ID from Play Services is asynchronous. This
means events fired before we have the advertising ID may not have this
information available.

This commit makes a few changes to deal with this. First we setup a
CountDownLatch to synchronize between the GetAdvertisindIdTask and the
enqueuing code. This has the potential to block enqueues for a while, so
we implement a 5 second timeout for waiting. The latch is released
either if play services is not available or when the task completes.

Additionally, this makes the code to fire application lifecycle events
async as well, so that we don't block initialization for too long.