### PR TITLE
Collect advertisingId even if isLimitAdTrackingEnabled is true

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/GetAdvertisingIdTask.java
+++ b/analytics/src/main/java/com/segment/analytics/GetAdvertisingIdTask.java
@@ -33,14 +33,12 @@ class GetAdvertisingIdTask extends AsyncTask<Context, Void, Pair<String, Boolean
           .getMethod("isLimitAdTrackingEnabled")
           .invoke(advertisingInfo);
 
-      if (isLimitAdTrackingEnabled) {
-        logger.debug("Not collecting advertising ID because isLimitAdTrackingEnabled is true.");
-        return Pair.create(null, false);
-      }
+      // isNotLimitAdTrackingEnabled is equivalent to adTrackingEnabled.
+      boolean adTrackingEnabled = !isLimitAdTrackingEnabled;
 
       String advertisingId =
           (String) advertisingInfo.getClass().getMethod("getId").invoke(advertisingInfo);
-      return Pair.create(advertisingId, true);
+      return Pair.create(advertisingId, adTrackingEnabled);
     } catch (Exception e) {
       logger.error(e, "Unable to collect advertising ID.");
     }


### PR DESCRIPTION
Integrations will use `adTrackingEnabled` (which is equivalent to `!isLimitAdTrackingEnabled`) to check if they should use this for adTracking.