### PR TITLE
Namespace SharedPreferences

### DIFF
--- a/analytics-tests/build.gradle
+++ b/analytics-tests/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   }
 
   testCompile 'org.assertj:assertj-core:1.7.1'
+  testCompile 'com.squareup.assertj:assertj-android:1.1.1'
 
   testCompile 'org.mockito:mockito-core:1.10.19'
 

--- a/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -119,7 +119,7 @@ public class AnalyticsTest {
         .thenReturn(ProjectSettings.create(Cartographer.INSTANCE.fromJson(SETTINGS)));
 
     SharedPreferences sharedPreferences =
-        RuntimeEnvironment.application.getSharedPreferences("analytics-test", MODE_PRIVATE);
+        RuntimeEnvironment.application.getSharedPreferences("analytics-test-qaz", MODE_PRIVATE);
     optOut = new BooleanPreference(sharedPreferences, "opt-out-test", false);
 
     analytics = new Analytics(application, networkExecutor, stats, traitsCache, analyticsContext,
@@ -133,7 +133,7 @@ public class AnalyticsTest {
   }
 
   @After public void tearDown() {
-    RuntimeEnvironment.application.getSharedPreferences("analytics-android", MODE_PRIVATE)
+    RuntimeEnvironment.application.getSharedPreferences("analytics-android-qaz", MODE_PRIVATE)
         .edit()
         .clear()
         .commit();
@@ -630,7 +630,7 @@ public class AnalyticsTest {
     packageInfo.versionName = "1.0.1";
 
     SharedPreferences sharedPreferences =
-        RuntimeEnvironment.application.getSharedPreferences("analytics-android", MODE_PRIVATE);
+        RuntimeEnvironment.application.getSharedPreferences("analytics-android-qaz", MODE_PRIVATE);
     SharedPreferences.Editor editor = sharedPreferences.edit();
     editor.putInt("build", 100);
     editor.putString("version", "1.0.0");

--- a/analytics-tests/src/test/java/com/segment/analytics/ValueMapCacheTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/ValueMapCacheTest.java
@@ -21,7 +21,7 @@ public class ValueMapCacheTest {
     cartographer = Cartographer.INSTANCE;
     traitsCache =
         new ValueMap.Cache<>(RuntimeEnvironment.application, cartographer, "traits-cache-test",
-            Traits.class);
+            "tag", Traits.class);
     traitsCache.delete();
     assertThat(traitsCache.get()).isNullOrEmpty();
   }
@@ -39,7 +39,7 @@ public class ValueMapCacheTest {
 
     ValueMap.Cache<Traits> traitsCacheDuplicate =
         new ValueMap.Cache<>(RuntimeEnvironment.application, cartographer, "traits-cache-test",
-            Traits.class);
+            "tag", Traits.class);
     assertThat(traitsCacheDuplicate.isSet()).isTrue();
   }
 }

--- a/analytics-tests/src/test/java/com/segment/analytics/internal/UtilsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/internal/UtilsTest.java
@@ -25,9 +25,12 @@
 package com.segment.analytics.internal;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import com.segment.analytics.core.tests.BuildConfig;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.assertj.core.data.MapEntry;
@@ -36,6 +39,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static android.Manifest.permission.ACCESS_NETWORK_STATE;
@@ -43,6 +47,7 @@ import static android.content.pm.PackageManager.PERMISSION_DENIED;
 import static com.segment.analytics.internal.Utils.isConnected;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 import static com.segment.analytics.internal.Utils.transform;
+import static org.assertj.android.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -124,5 +129,31 @@ public class UtilsTest {
     Map<String, String> map = new Utils.NullableConcurrentHashMap<>();
     map.putAll(values);
     assertThat(map).isEmpty();
+  }
+
+  @Test public void copySharedPreferences() {
+    SharedPreferences src =
+        RuntimeEnvironment.application.getSharedPreferences("src", Context.MODE_PRIVATE);
+    src.edit().clear().apply();
+    src.edit()
+        .putBoolean("aBool", true)
+        .putString("aString", "foo")
+        .putInt("anInt", 2)
+        .putFloat("aFloat", 3.14f)
+        .putLong("aLong", 12345678910L)
+        .putStringSet("aStringSet", new HashSet<>(Arrays.asList("foo", "bar")))
+        .apply();
+
+    SharedPreferences target =
+        RuntimeEnvironment.application.getSharedPreferences("target", Context.MODE_PRIVATE);
+    target.edit().clear().apply();
+
+    Utils.copySharedPreferences(src, target);
+    assertThat(target).contains("aBool", true)
+        .contains("aString", "foo")
+        .contains("anInt", 2)
+        .contains("aFloat", 3.14f)
+        .contains("aLong", 12345678910L)
+        .contains("aStringSet", new HashSet<>(Arrays.asList("foo", "bar")));
   }
 }

--- a/analytics/src/main/java/com/segment/analytics/ProjectSettings.java
+++ b/analytics/src/main/java/com/segment/analytics/ProjectSettings.java
@@ -68,10 +68,13 @@ class ProjectSettings extends ValueMap {
 
   static class Cache extends ValueMap.Cache<ProjectSettings> {
 
+    // todo: remove. This is legacy behaviour from before we started namespacing the entire shared
+    // preferences object and were namespacing keys instead.
     private static final String PROJECT_SETTINGS_CACHE_KEY_PREFIX = "project-settings-plan-";
 
     Cache(Context context, Cartographer cartographer, String tag) {
-      super(context, cartographer, PROJECT_SETTINGS_CACHE_KEY_PREFIX + tag, ProjectSettings.class);
+      super(context, cartographer, PROJECT_SETTINGS_CACHE_KEY_PREFIX + tag, tag,
+          ProjectSettings.class);
     }
 
     @Override public ProjectSettings create(Map<String, Object> map) {

--- a/analytics/src/main/java/com/segment/analytics/Traits.java
+++ b/analytics/src/main/java/com/segment/analytics/Traits.java
@@ -403,10 +403,12 @@ public class Traits extends ValueMap {
 
   static class Cache extends ValueMap.Cache<Traits> {
 
+    // todo: remove. This is legacy behaviour from before we started namespacing the entire shared
+    // preferences object and were namespacing keys instead.
     private static final String TRAITS_CACHE_PREFIX = "traits-";
 
     Cache(Context context, Cartographer cartographer, String tag) {
-      super(context, cartographer, TRAITS_CACHE_PREFIX + tag, Traits.class);
+      super(context, cartographer, TRAITS_CACHE_PREFIX + tag, tag, Traits.class);
     }
 
     @Override public Traits create(Map<String, Object> map) {

--- a/analytics/src/main/java/com/segment/analytics/ValueMap.java
+++ b/analytics/src/main/java/com/segment/analytics/ValueMap.java
@@ -354,9 +354,9 @@ public class ValueMap implements Map<String, Object> {
     private final Class<T> clazz;
     private T value;
 
-    Cache(Context context, Cartographer cartographer, String key, Class<T> clazz) {
+    Cache(Context context, Cartographer cartographer, String key, String tag, Class<T> clazz) {
       this.cartographer = cartographer;
-      this.preferences = getSegmentSharedPreferences(context);
+      this.preferences = getSegmentSharedPreferences(context, tag);
       this.key = key;
       this.clazz = clazz;
     }

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -179,8 +179,8 @@ public final class Utils {
   }
 
   /** Returns a shared preferences for storing any library preferences. */
-  public static SharedPreferences getSegmentSharedPreferences(Context context) {
-    return context.getSharedPreferences("analytics-android", MODE_PRIVATE);
+  public static SharedPreferences getSegmentSharedPreferences(Context context, String tag) {
+    return context.getSharedPreferences("analytics-android-" + tag, MODE_PRIVATE);
   }
 
   /** Get the string resource for the given key. Returns null if not found. */
@@ -367,6 +367,29 @@ public final class Utils {
     if (!(location.exists() || location.mkdirs() || location.isDirectory())) {
       throw new IOException("Could not create directory at " + location);
     }
+  }
+
+  /** Copies all the values from {@code src} to {@code target}. */
+  public static void copySharedPreferences(SharedPreferences src, SharedPreferences target) {
+    SharedPreferences.Editor editor = target.edit();
+    for (Map.Entry<String, ?> entry : src.getAll().entrySet()) {
+      String key = entry.getKey();
+      Object value = entry.getValue();
+      if (value instanceof String) {
+        editor.putString(key, (String) value);
+      } else if (value instanceof Set) {
+        editor.putStringSet(key, (Set<String>) value);
+      } else if (value instanceof Integer) {
+        editor.putInt(key, (Integer) value);
+      } else if (value instanceof Long) {
+        editor.putLong(key, (Long) value);
+      } else if (value instanceof Float) {
+        editor.putFloat(key, (Float) value);
+      } else if (value instanceof Boolean) {
+        editor.putBoolean(key, (Boolean) value);
+      }
+    }
+    editor.apply();
   }
 
   private Utils() {


### PR DESCRIPTION
Previously (until version 4.1.6 and the upcoming 4.1.7 release) shared preferences were not namespaced by a tag.

This meant that all analytics instances shared the same shared
preferences.

Going forwards, the preferences will be namespaced, and a migration is
added to copy over old preferences.

Also fixes the reset method to blow the entire sharedPreferences object.