### PR TITLE
Fix Properties.putProducts()

### DIFF
--- a/analytics-tests/src/test/java/com/segment/analytics/PropertiesTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/PropertiesTest.java
@@ -1,0 +1,16 @@
+package com.segment.analytics;
+
+import com.segment.analytics.Properties.Product;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PropertiesTest {
+  @Test public void products() {
+    Product product = new Product("foo", "bar", 10);
+    Properties properties = new Properties();
+    properties.putProducts(product);
+
+    assertThat(properties.products()).containsExactly(product);
+  }
+}

--- a/analytics/src/main/java/com/segment/analytics/Properties.java
+++ b/analytics/src/main/java/com/segment/analytics/Properties.java
@@ -24,6 +24,9 @@
 
 package com.segment.analytics;
 
+import com.segment.analytics.internal.Utils;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -336,10 +339,20 @@ public class Properties extends ValueMap {
    * @see <a href="https://segment.com/docs/api/tracking/ecommerce/">Ecommerce API</a>
    */
   public Properties putProducts(Product... products) {
-    return putValue(PRODUCTS_KEY, products);
+    if (Utils.isNullOrEmpty(products)) {
+      throw new IllegalArgumentException("products cannot be null or empty.");
+    }
+    List<Product> productList = new ArrayList<>(products.length);
+    Collections.addAll(productList, products);
+    return putValue(PRODUCTS_KEY, Collections.unmodifiableList(productList));
   }
 
+  /** @deprecated Use {@link #products()} instead. */
   public List<Product> products(Product... products) {
+    return products();
+  }
+
+  public List<Product> products() {
     return getList(PRODUCTS_KEY, Product.class);
   }
 

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -142,9 +142,14 @@ public final class Utils {
     return TextUtils.isEmpty(text) || TextUtils.getTrimmedLength(text) == 0;
   }
 
-  /** Returns true if the collection or has a size 0. */
+  /** Returns true if the collection is null or has a size of 0. */
   public static boolean isNullOrEmpty(Collection collection) {
     return collection == null || collection.size() == 0;
+  }
+
+  /** Returns true if the array is null or has a size of 0. */
+  public static <T> boolean isNullOrEmpty(T[] data) {
+    return data == null || data.length == 0;
   }
 
   /** Returns true if the map is null or empty, false otherwise. */


### PR DESCRIPTION
Previously putProducts was storing an array instead of copying the
array to a list.

With Segment specifically this also caused issues with serialization.

```
"properties": {
    "products": "[Lcom.segment.analytics.Properties$Product;@36db3d6"
}
```