### PR TITLE
Update Android grade plugin

### DIFF
--- a/analytics-tests/build.gradle
+++ b/analytics-tests/build.gradle
@@ -8,7 +8,7 @@ dependencies {
   compile project(':analytics')
 
   testCompile 'junit:junit:4.12'
-  testCompile('org.robolectric:robolectric:3.0-rc2') {
+  testCompile('org.robolectric:robolectric:3.1.4') {
     exclude group: 'commons-logging', module: 'commons-logging'
     exclude group: 'org.apache.httpcomponents', module: 'httpclient'
   }

--- a/analytics-tests/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static android.Manifest.permission.INTERNET;
@@ -47,8 +47,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
 public class AnalyticsBuilderTest {
 
   Application context;

--- a/analytics-tests/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -6,16 +6,17 @@ import org.assertj.core.data.MapEntry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static com.segment.analytics.Utils.createContext;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class AnalyticsContextTest {
 
   AnalyticsContext analyticsContext;
@@ -41,9 +42,9 @@ public class AnalyticsContextTest {
 
     assertThat(analyticsContext.getValueMap("app")) //
         .containsEntry("name", "com.segment.analytics.core.tests")
-        .containsEntry("version", BuildConfig.VERSION_NAME)
+        .containsEntry("version", "undefined")
         .containsEntry("namespace", "com.segment.analytics.core.tests")
-        .containsEntry("build", BuildConfig.VERSION_CODE);
+        .containsEntry("build", 0);
 
     assertThat(analyticsContext.getValueMap("device")) //
         .containsEntry("id", "unknown")
@@ -60,7 +61,7 @@ public class AnalyticsContextTest {
 
     assertThat(analyticsContext.getValueMap("os")) //
         .containsEntry("name", "Android") //
-        .containsEntry("version", "unknown");
+        .containsEntry("version", "4.3_r2");
 
     assertThat(analyticsContext.getValueMap("screen")) //
         .containsEntry("density", 1.5f) //

--- a/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -35,7 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
@@ -63,8 +63,8 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
 public class AnalyticsTest {
   private static final String SETTINGS = "{\n"
       + "  \"integrations\": {\n"

--- a/analytics-tests/src/test/java/com/segment/analytics/BatchPayloadWriterTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/BatchPayloadWriterTest.java
@@ -6,14 +6,15 @@ import java.io.IOException;
 import java.util.Date;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.segment.analytics.internal.Utils.toISO8601Date;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class BatchPayloadWriterTest {
 
   @Test public void batchPayloadWriter() throws IOException {

--- a/analytics-tests/src/test/java/com/segment/analytics/CartographerTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/CartographerTest.java
@@ -6,15 +6,16 @@ import java.io.IOException;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.segment.analytics.TestUtils.TRACK_PAYLOAD;
 import static com.segment.analytics.TestUtils.TRACK_PAYLOAD_JSON;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class CartographerTest {
 
   @Test public void testSerialization() throws IOException {

--- a/analytics-tests/src/test/java/com/segment/analytics/ClientTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/ClientTest.java
@@ -17,7 +17,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.fail;
@@ -25,9 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class ClientTest {
 
   @Rule public MockWebServerRule server = new MockWebServerRule();

--- a/analytics-tests/src/test/java/com/segment/analytics/CryptoTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/CryptoTest.java
@@ -7,13 +7,14 @@ import okio.ByteString;
 import okio.Okio;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class CryptoTest {
   @Test public void noneCryptoWrite() throws IOException {
     Crypto crypto = Crypto.none();

--- a/analytics-tests/src/test/java/com/segment/analytics/LoggerTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/LoggerTest.java
@@ -5,14 +5,15 @@ import com.segment.analytics.core.tests.BuildConfig;
 import com.segment.analytics.integrations.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class LoggerTest {
 
   @Test public void verboseLevelLogsEverything() {

--- a/analytics-tests/src/test/java/com/segment/analytics/OptionsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/OptionsTest.java
@@ -4,15 +4,15 @@ import com.segment.analytics.core.tests.BuildConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
-public class OptionsTest {
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE) public class OptionsTest {
 
   Options options;
 

--- a/analytics-tests/src/test/java/com/segment/analytics/ProjectSettingsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/ProjectSettingsTest.java
@@ -4,14 +4,15 @@ import com.segment.analytics.core.tests.BuildConfig;
 import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class ProjectSettingsTest {
 
   @Test public void deserialization() throws IOException {

--- a/analytics-tests/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
@@ -24,7 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
@@ -52,8 +52,8 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = Config.NONE)
 public class SegmentIntegrationTest {
 
   @Rule public TemporaryFolder folder = new TemporaryFolder();

--- a/analytics-tests/src/test/java/com/segment/analytics/StatsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/StatsTest.java
@@ -31,14 +31,15 @@ import org.assertj.core.data.MapEntry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class StatsTest {
 
   Stats stats;

--- a/analytics-tests/src/test/java/com/segment/analytics/TraitsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/TraitsTest.java
@@ -6,14 +6,15 @@ import org.assertj.core.data.MapEntry;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class TraitsTest {
 
   Traits traits;

--- a/analytics-tests/src/test/java/com/segment/analytics/ValueMapCacheTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/ValueMapCacheTest.java
@@ -4,14 +4,15 @@ import com.segment.analytics.core.tests.BuildConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class ValueMapCacheTest {
 
   private ValueMap.Cache<Traits> traitsCache;

--- a/analytics-tests/src/test/java/com/segment/analytics/ValueMapTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/ValueMapTest.java
@@ -10,7 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.segment.analytics.TestUtils.PROJECT_SETTINGS_JSON_SAMPLE;
@@ -19,9 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class ValueMapTest {
 
   @Mock NullableConcurrentHashMap<String, Object> delegate;

--- a/analytics-tests/src/test/java/com/segment/analytics/integrations/BasePayloadTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/integrations/BasePayloadTest.java
@@ -4,18 +4,18 @@ import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.Options;
 import com.segment.analytics.Traits;
 import com.segment.analytics.core.tests.BuildConfig;
-import com.segment.analytics.integrations.BasePayload;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE)
 public class BasePayloadTest {
 
   @Test public void newInvocationIsCreatedWithDefaults() {

--- a/analytics-tests/src/test/java/com/segment/analytics/internal/UtilsTest.java
+++ b/analytics-tests/src/test/java/com/segment/analytics/internal/UtilsTest.java
@@ -38,7 +38,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
@@ -51,10 +51,10 @@ import static org.assertj.android.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.robolectric.annotation.Config.NONE;
 
-@RunWith(RobolectricGradleTestRunner.class)
-@Config(constants = BuildConfig.class, emulateSdk = 18, manifest = Config.NONE)
-public class UtilsTest {
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 18, manifest = NONE) public class UtilsTest {
 
   @Mock Context context;
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
   repositories {
     mavenCentral()
+    jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.3'
+    classpath 'com.android.tools.build:gradle:2.2.3'
     classpath 'com.f2prateek.checkstyle:checkstyle:1.0.1'
   }
 }
@@ -12,6 +13,7 @@ allprojects {
   buildscript {
     repositories {
       mavenCentral()
+      jcenter()
     }
   }
 

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -26,7 +26,6 @@ android {
     }
   }
 
-
   compileOptions {
     sourceCompatibility rootProject.ext.sourceCompatibilityVersion
     targetCompatibility rootProject.ext.targetCompatibilityVersion


### PR DESCRIPTION
This also adds jcenter because this is where the new plugin versions are
hosted.

This also updates Robolectric, because the plugin update changes build
outputs that Robolectric relies on:

```
java.lang.RuntimeException: java.lang.RuntimeException:
build/intermediates/manifests/full/debug/AndroidManifest.xml not found
or not a file; it should point to your project's AndroidManifest.xml
```