### PR TITLE
Remove PowerMock dependency for testing.

### DIFF
--- a/analytics-tests/build.gradle
+++ b/analytics-tests/build.gradle
@@ -12,19 +12,10 @@ dependencies {
     exclude group: 'commons-logging', module: 'commons-logging'
     exclude group: 'org.apache.httpcomponents', module: 'httpclient'
   }
-
   testCompile 'org.assertj:assertj-core:1.7.1'
   testCompile 'com.squareup.assertj:assertj-android:1.1.1'
-
   testCompile 'org.mockito:mockito-core:1.10.19'
   testCompile 'com.squareup.okio:okio:1.10.0'
-
-  testCompile 'org.powermock:powermock:1.6.2'
-  testCompile 'org.powermock:powermock-module-junit4:1.6.2'
-  testCompile 'org.powermock:powermock-module-junit4-rule:1.6.2'
-  testCompile 'org.powermock:powermock-api-mockito:1.6.2'
-  testCompile 'org.powermock:powermock-classloading-xstream:1.6.2'
-
   testCompile 'com.squareup.okhttp:mockwebserver:2.3.0'
 }
 


### PR DESCRIPTION
We don't use this anymore.