### PR TITLE
Fix calling to getInputStream on errors

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -27,6 +27,7 @@ package com.segment.analytics;
 import static com.segment.analytics.internal.Utils.assertNotNull;
 import static com.segment.analytics.internal.Utils.buffer;
 import static com.segment.analytics.internal.Utils.closeQuietly;
+import static com.segment.analytics.internal.Utils.getInputStream;
 import static com.segment.analytics.internal.Utils.getResourceString;
 import static com.segment.analytics.internal.Utils.getSegmentSharedPreferences;
 import static com.segment.analytics.internal.Utils.hasPermission;
@@ -360,7 +361,7 @@ public class Analytics {
 
       // Read the response body.
       Map<String, Object> map =
-          cartographer.fromJson(buffer(connection.connection.getInputStream()));
+          cartographer.fromJson(buffer(getInputStream(connection.connection)));
       Properties properties = new Properties(map);
 
       track("Install Attributed", properties);

--- a/analytics/src/main/java/com/segment/analytics/Client.java
+++ b/analytics/src/main/java/com/segment/analytics/Client.java
@@ -25,6 +25,7 @@
 package com.segment.analytics;
 
 import static com.segment.analytics.internal.Utils.readFully;
+import static com.segment.analytics.internal.Utils.getInputStream;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 import android.text.TextUtils;
@@ -58,7 +59,7 @@ class Client {
           if (responseCode >= 300) {
             String responseBody;
             try {
-              responseBody = readFully(connection.getInputStream());
+              responseBody = readFully(getInputStream(connection));
             } catch (IOException e) {
               responseBody = "Could not read response body for rejected message: " + e.toString();
             }
@@ -73,7 +74,7 @@ class Client {
   }
 
   private static Connection createGetConnection(HttpURLConnection connection) throws IOException {
-    return new Connection(connection, connection.getInputStream(), null) {
+    return new Connection(connection, getInputStream(connection), null) {
       @Override
       public void close() throws IOException {
         super.close();

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -52,6 +52,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Array;
+import java.net.HttpURLConnection;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -349,6 +350,14 @@ public final class Utils {
       sb.append(line);
     }
     return sb.toString();
+  }
+
+  public static InputStream getInputStream(HttpURLConnection connection) throws IOException {
+    try {
+      return connection.getInputStream();
+    } catch (IOException ignored) {
+      return connection.getErrorStream();
+    }
   }
 
   /**


### PR DESCRIPTION
When the status code is above 300 (Don't know for sure if for all codes, but for some of them for sure), `getInputStream()` throws `FileNotFoundException` and the stream is in `getErrorStream()`.