### PR TITLE
Test Updates

### DIFF
--- a/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -41,7 +41,7 @@ public class AnalyticsContextTest {
         .containsKey("app") //
         .containsKey("device") //
         .containsKey("library") //
-        .containsEntry("locale", "en-US") //
+        .containsKey("locale") //
         .containsKey("network") //
         .containsKey("os") //
         .containsKey("screen")
@@ -76,15 +76,17 @@ public class AnalyticsContextTest {
         .containsEntry("density", 1.5f) //
         .containsEntry("width", 480) //
         .containsEntry("height", 800);
+  }
 
-    // disable device id collection
+  @Test
+  public void createWithoutDeviceIdCollection() {
     context = AnalyticsContext.create(RuntimeEnvironment.application, traits, false);
 
     assertThat(context.getValueMap("device")) //
-        .containsEntry("id", traits.anonymousId())
-        .containsEntry("manufacturer", "unknown")
-        .containsEntry("model", "unknown")
-        .containsEntry("name", "unknown");
+            .containsEntry("id", traits.anonymousId())
+            .containsEntry("manufacturer", "unknown")
+            .containsEntry("model", "unknown")
+            .containsEntry("name", "unknown");
   }
 
   @Test


### PR DESCRIPTION
1. Split AnalyticsContext create test into two.
2. Only check for local key, not value because we might be running tests on non en-US locale computers.