### PR TITLE
Add jcenter to allprojects/repositories block in top-level build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ allprojects {
 
   repositories {
     mavenCentral()
+    jcenter()
   }
 
   group = GROUP


### PR DESCRIPTION
Adding jcenter() to the top-level build.gradle file will help eliminate confusion on the Success Team - I just came from a meeting where they weren't able to compile dependencies into our sample projects because the jcenter() repo was not included anywhere. This PR solves that problem.