### PR TITLE
Support schema defaults for new events.

### DIFF
--- a/analytics/src/test/java/com/segment/analytics/IntegrationOperationTest.java
+++ b/analytics/src/test/java/com/segment/analytics/IntegrationOperationTest.java
@@ -88,7 +88,7 @@ public class IntegrationOperationTest {
   }
 
   @Test
-  public void trackNoEventPlan() throws IOException {
+  public void trackPlanForEvent() throws IOException {
     TrackPayload payload = new TrackPayload.Builder()
         .event("Install Attributed")
         .userId("userId")
@@ -105,6 +105,50 @@ public class IntegrationOperationTest {
                 + "  }\n"
                 + "}"));
     verify(integration).track(payload);
+  }
+
+
+  @Test
+  public void trackWithOptionsAndWithoutEventPlan() throws IOException {
+    TrackPayload payload = new TrackPayload.Builder()
+            .event("Install Attributed")
+            .userId("userId")
+            .integrations(ImmutableMap.of("Mixpanel", false))
+            .build();
+    track(
+            payload,
+            "Mixpanel",
+            Cartographer.INSTANCE.fromJson(
+                    "{\n"
+                            + "  \"plan\": {\n"
+                            + "    \"track\": {\n"
+                            + "      \"Completed Order\": {}\n"
+                            + "    }\n"
+                            + "  }\n"
+                            + "}"));
+    verify(integration, never()).track(payload);
+  }
+
+
+  @Test
+  public void trackPlanForEventWithOptions() throws IOException {
+    TrackPayload payload = new TrackPayload.Builder()
+            .event("Install Attributed")
+            .userId("userId")
+            .integrations(Collections.singletonMap("All", false))
+            .build();
+    track(
+            payload,
+            "Mixpanel",
+            Cartographer.INSTANCE.fromJson(
+                    "{\n"
+                            + "  \"plan\": {\n"
+                            + "    \"track\": {\n"
+                            + "      \"Completed Order\": {}\n"
+                            + "    }\n"
+                            + "  }\n"
+                            + "}"));
+    verify(integration, never()).track(payload);
   }
 
   @Test
@@ -221,5 +265,96 @@ public class IntegrationOperationTest {
                 + "  }\n"
                 + "}"));
     verify(integration).track(payload);
+  }
+
+  @Test
+  public void defaultNewEventsEnabled() throws IOException {
+    TrackPayload payload = new TrackPayload.Builder()
+            .event("Install Attributed")
+            .userId("userId")
+            .build();
+    track(
+            payload,
+            "Segment.io",
+            Cartographer.INSTANCE.fromJson(
+                    "{\n" +
+                            "  \"plan\": {\n" +
+                            "    \"track\": {\n" +
+                            "      \"__default\": {\n" +
+                            "        \"enabled\": true\n" +
+                            "      }\n" +
+                            "    }\n" +
+                            "  }\n" +
+                            "}"));
+    verify(integration).track(payload);
+  }
+
+  @Test
+  public void defaultNewEventsDisabled() throws IOException {
+    TrackPayload payload = new TrackPayload.Builder()
+            .event("Install Attributed")
+            .userId("userId")
+            .build();
+    track(
+            payload,
+            "Mixpanel",
+            Cartographer.INSTANCE.fromJson(
+                    "{\n" +
+                            "  \"plan\": {\n" +
+                            "    \"track\": {\n" +
+                            "      \"__default\": {\n" +
+                            "        \"enabled\": false\n" +
+                            "      }\n" +
+                            "    }\n" +
+                            "  }\n" +
+                            "}"));
+    verify(integration, never()).track(payload);
+  }
+
+  @Test
+  public void defaultNewEventsDisabledSendToSegment() throws IOException {
+    TrackPayload payload = new TrackPayload.Builder()
+            .event("Install Attributed")
+            .userId("userId")
+            .build();
+    track(
+            payload,
+            "Segment.io",
+            Cartographer.INSTANCE.fromJson(
+                    "{\n" +
+                            "  \"plan\": {\n" +
+                            "    \"track\": {\n" +
+                            "      \"__default\": {\n" +
+                            "        \"enabled\": false\n" +
+                            "      }\n" +
+                            "    }\n" +
+                            "  }\n" +
+                            "}"));
+    verify(integration).track(payload);
+  }
+
+  @Test
+  public void eventPlanOverridesSchemaDefault() throws IOException {
+    TrackPayload payload = new TrackPayload.Builder()
+            .event("Install Attributed")
+            .userId("userId")
+            .build();
+    track(
+            payload,
+            "Mixpanel",
+            Cartographer.INSTANCE.fromJson(
+                    "{\n" +
+                            "  \"plan\": {\n" +
+                            "    \"track\": {\n" +
+                            "      \"__default\": {\n" +
+                            "        \"enabled\": true\n" +
+                            "      },\n" +
+                            "      \"Install Attributed\": {\n" +
+                            "        \"enabled\": false\n" +
+                            "      }\n" +
+                            "    }\n" +
+                            "  }\n" +
+                            "}"));
+    verify(integration, never()).track(payload);
   }
 }


### PR DESCRIPTION
If an event is not present in the tracking plan, we'll now lookup the schema defaults for the project.

If the event is disabled in the schema default, it will only be sent to the Segment integration (i.e. api.segment.io).

If the event is enabled in the schema default, it will be sent to all integrations.

Ref: https://paper.dropbox.com/doc/Schema-Client-Side-Defaults-DufdS8Ej43mnFXvvMqm1b