### PR TITLE
Fix or suppress all Lint warnings

### DIFF
--- a/analytics-samples/analytics-sample/build.gradle
+++ b/analytics-samples/analytics-sample/build.gradle
@@ -3,6 +3,13 @@ apply plugin: 'com.f2prateek.javafmt'
 
 apply from: rootProject.file('gradle/android.gradle')
 
+android {
+  lintOptions {
+    // Since this is just a sample app, it's ok to ignore these warnings.
+    disable 'IconMissingDensityFolder', 'GoogleAppIndexingWarning', 'AllowBackup'
+  }
+}
+
 dependencies {
   compile project(':analytics')
   compile project(':analytics-wear')

--- a/analytics-samples/analytics-wear-sample/build.gradle
+++ b/analytics-samples/analytics-wear-sample/build.gradle
@@ -7,10 +7,17 @@ android {
   defaultConfig {
     minSdkVersion rootProject.ext.minSdkVersionWear
   }
+
+  lintOptions {
+    // Since this is just a sample app, it's ok to ignore these warnings.
+    disable 'IconMissingDensityFolder', 'GoogleAppIndexingWarning', 'AllowBackup'
+  }
 }
 
 dependencies {
   compile project(':analytics')
   compile project(':analytics-wear')
+  // TODO: Update this dependency alongside the GPS dependency in analytics-wear.
+  //noinspection GradleDependency
   compile 'com.google.android.support:wearable:1.1.0'
 }

--- a/analytics-wear/build.gradle
+++ b/analytics-wear/build.gradle
@@ -6,6 +6,8 @@ apply from: rootProject.file('gradle/android.gradle')
 dependencies {
   compile project(':analytics')
 
+  // TODO: we should update this dependency.
+  //noinspection GradleDependency
   compile 'com.google.android.gms:play-services-wearable:10.2.6'
 }
 

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -34,6 +34,7 @@ import static com.segment.analytics.internal.Utils.hasPermission;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
@@ -108,7 +109,10 @@ public class Analytics {
   @Private static final String OPT_OUT_PREFERENCE_KEY = "opt-out";
   static final String WRITE_KEY_RESOURCE_IDENTIFIER = "analytics_write_key";
   static final List<String> INSTANCES = new ArrayList<>(1);
+  /* This is intentional since we're only using the application context. */
+  @SuppressLint("StaticFieldLeak")
   static volatile Analytics singleton = null;
+
   @Private static final Properties EMPTY_PROPERTIES = new Properties();
   private static final String VERSION_KEY = "version";
   private static final String BUILD_KEY = "build";

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -248,7 +248,11 @@ public final class Utils {
     return Collections.unmodifiableList(new ArrayList<>(list));
   }
 
-  /** Creates a unique device id. */
+  /**
+   * Creates a unique device id. Suppresses `HardwareIds` lint warnings as we don't use this ID for
+   * identifying specific users. This is also what is required by the Segment spec.
+   */
+  @SuppressLint("HardwareIds")
   public static String getDeviceId(Context context) {
     String androidId = getString(context.getContentResolver(), ANDROID_ID);
     if (!isNullOrEmpty(androidId)
@@ -258,7 +262,7 @@ public final class Utils {
       return androidId;
     }
 
-    // Serial number, guaranteed to be on all non phones in 2.3+
+    // Serial number, guaranteed to be on all non phones in 2.3+.
     if (!isNullOrEmpty(Build.SERIAL)) {
       return Build.SERIAL;
     }


### PR DESCRIPTION
The update in #556 added some new lint warnings. This fixes or suppresses all of them.

Full list:

```
/home/circleci/analytics-android/analytics-wear/build.gradle:9: Warning: A newer version of com.google.android.gms:play-services-wearable than 10.2.6 is available: 11.0.4 [GradleDependency]
  compile 'com.google.android.gms:play-services-wearable:10.2.6'
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/circleci/analytics-android/analytics-samples/analytics-wear-sample/build.gradle:15: Warning: A newer version of com.google.android.support:wearable than 1.1.0 is available: 2.0.5 [GradleDependency]
  compile 'com.google.android.support:wearable:1.1.0'
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "GradleDependency":
   This detector looks for usages of libraries where the version you are using
   is not the current stable release. Using older versions is fine, and there
   are cases where you deliberately want to stick with an older version.
   However, you may simply not be aware that a more recent version is
   available, and that is what this lint check helps find.

/home/circleci/analytics-android/analytics/src/main/java/com/segment/analytics/internal/Utils.java:253: Warning: Using getString to get device identifiers is not recommended. [HardwareIds]
    String androidId = getString(context.getContentResolver(), ANDROID_ID);
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/circleci/analytics-android/analytics/src/main/java/com/segment/analytics/internal/Utils.java:262: Warning: Using SERIAL to get device identifiers is not recommended. [HardwareIds]
    if (!isNullOrEmpty(Build.SERIAL)) {
                             ~~~~~~
/home/circleci/analytics-android/analytics/src/main/java/com/segment/analytics/internal/Utils.java:263: Warning: Using SERIAL to get device identifiers is not recommended. [HardwareIds]
      return Build.SERIAL;
                   ~~~~~~
/home/circleci/analytics-android/analytics/src/main/java/com/segment/analytics/internal/Utils.java:270: Warning: Using getDeviceId to get device identifiers is not recommended. [HardwareIds]
      String telephonyId = telephonyManager.getDeviceId();
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "HardwareIds":
   Using these device identifiers is not recommended other than for high value
   fraud prevention and advanced telephony use-cases. For advertising
   use-cases, use AdvertisingIdClient$Info#getId and for analytics, use
   InstanceId#getId.

   https://developer.android.com/training/articles/user-data-ids.html

/home/circleci/analytics-android/analytics-samples/analytics-wear-sample/src/main/AndroidManifest.xml:7: Warning: On SDK version 23 and up, your app data will be automatically backed up and restored on app install. Consider adding the attribute android:fullBackupContent to specify an @xml resource which configures which files to backup. More info: https://developer.android.com/training/backup/autosyncapi.html [AllowBackup]
  <application
  ^

   Explanation for issues of type "AllowBackup":
   The allowBackup attribute determines if an application's data can be backed
   up and restored. It is documented at
   http://developer.android.com/reference/android/R.attr.html#allowBackup

   By default, this flag is set to true. When this flag is set to true,
   application data can be backed up and restored by the user using adb backup
   and adb restore.

   This may have security consequences for an application. adb backup allows
   users who have enabled USB debugging to copy application data off of the
   device. Once backed up, all application data can be read by the user. adb
   restore allows creation of application data from a source specified by the
   user. Following a restore, applications should not assume that the data,
   file permissions, and directory permissions were created by the application
   itself.

   Setting allowBackup="false" opts an application out of both backup and
   restore.

   To fix this warning, decide whether your application should support backup,
   and explicitly set android:allowBackup=(true|false)".

   If not set to false, and if targeting API 23 or later, lint will also warn
   that you should set android:fullBackupContent to configure auto backup.

   https://developer.android.com/training/backup/autosyncapi.html

/home/circleci/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:111: Warning: Do not place Android context classes in static fields (static reference to Analytics which has field application pointing to Application); this is a memory leak (and also breaks Instant Run) [StaticFieldLeak]
  static volatile Analytics singleton = null;
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "StaticFieldLeak":
   A static field will leak contexts.

/home/circleci/analytics-android/analytics-samples/analytics-wear-sample/src/main/res: Warning: Missing density variation folders in src/main/res: drawable-mdpi, drawable-hdpi, drawable-xhdpi [IconMissingDensityFolder]

   Explanation for issues of type "IconMissingDensityFolder":
   Icons will look best if a custom version is provided for each of the major
   screen density classes (low, medium, high, extra-high, extra-extra-high).
   This lint check identifies folders which are missing, such as
   drawable-hdpi.

   Low density is not really used much anymore, so this check ignores the ldpi
   density. To force lint to include it, set the environment variable
   ANDROID_LINT_INCLUDE_LDPI=true. For more information on current density
   usage, see http://developer.android.com/resources/dashboard/screens.html

   http://developer.android.com/guide/practices/screens_support.html

/home/circleci/analytics-android/analytics-samples/analytics-wear-sample/src/main/AndroidManifest.xml:7: Warning: App is not indexable by Google Search; consider adding at least one Activity with an ACTION-VIEW intent filter. See issue explanation for more details. [GoogleAppIndexingWarning]
  <application
  ^

   Explanation for issues of type "GoogleAppIndexingWarning":
   Adds URLs to get your app into the Google index, to get installs and
   traffic to your app from Google Search.

   https://g.co/AppIndexing/AndroidStudio
```