### PR TITLE
Update build plugin to 3.0.1

### DIFF
--- a/analytics-samples/analytics-sample/build.gradle
+++ b/analytics-samples/analytics-sample/build.gradle
@@ -15,6 +15,6 @@ dependencies {
   compile project(':analytics-wear')
 
   compile 'com.jakewharton:butterknife:8.6.0'
-  provided 'com.jakewharton:butterknife-compiler:8.6.0'
+  annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
   compile 'uk.co.chrisjenx:calligraphy:2.2.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@ buildscript {
   repositories {
     mavenCentral()
     jcenter()
+    google()
   }
+
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.0.1'
     classpath 'com.vanniktech:gradle-android-junit-jacoco-plugin:0.5.0'
     classpath 'com.f2prateek.javafmt:javafmt:0.1.6'
     classpath 'com.getkeepsafe.dexcount:dexcount-gradle-plugin:0.6.2'


### PR DESCRIPTION
* Need to add the google repo to the buildscript since that's where the new versions are hosted.
* Butterknife change is required to fix this error:

```
> Annotation processors must be explicitly declared now.  The following dependencies on the compile classpath are found to contain annotation processor.  Please add them to the annotationProcessor configuration.
    - butterknife-compiler-8.6.0.jar (com.jakewharton:butterknife-compiler:8.6.0)
  Alternatively, set android.defaultConfig.javaCompileOptions.annotationProcessorOptions.includeCompileClasspath = true to continue with previous behavior.  Note that this option is deprecated and will be removed in the future.
  See https://developer.android.com/r/tools/annotation-processor-error-message.html for more details.
```