### PR TITLE
Use new dependency configurations.

### DIFF
--- a/analytics-samples/analytics-sample/build.gradle
+++ b/analytics-samples/analytics-sample/build.gradle
@@ -11,10 +11,10 @@ android {
 }
 
 dependencies {
-  compile project(':analytics')
-  compile project(':analytics-wear')
+  implementation project(':analytics')
+  implementation project(':analytics-wear')
 
-  compile 'com.jakewharton:butterknife:8.6.0'
+  implementation 'uk.co.chrisjenx:calligraphy:2.2.0'
+  implementation 'com.jakewharton:butterknife:8.6.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
-  compile 'uk.co.chrisjenx:calligraphy:2.2.0'
 }

--- a/analytics-samples/analytics-wear-sample/build.gradle
+++ b/analytics-samples/analytics-wear-sample/build.gradle
@@ -15,9 +15,9 @@ android {
 }
 
 dependencies {
-  compile project(':analytics')
-  compile project(':analytics-wear')
+  implementation project(':analytics')
+  implementation project(':analytics-wear')
   // TODO: Update this dependency alongside the GPS dependency in analytics-wear.
   //noinspection GradleDependency
-  compile 'com.google.android.support:wearable:1.1.0'
+  implementation 'com.google.android.support:wearable:1.1.0'
 }

--- a/analytics-tests/build.gradle
+++ b/analytics-tests/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.f2prateek.javafmt'
 apply from: rootProject.file('gradle/android.gradle')
 
 dependencies {
-  compile project(':analytics')
+  api project(':analytics')
 }
 
 apply from: rootProject.file('gradle/attach-jar.gradle')

--- a/analytics-wear/build.gradle
+++ b/analytics-wear/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.f2prateek.javafmt'
 apply from: rootProject.file('gradle/android.gradle')
 
 dependencies {
-  compile project(':analytics')
+  api project(':analytics')
 
   // TODO: we should update this dependency.
   //noinspection GradleDependency
-  compile 'com.google.android.gms:play-services-wearable:10.2.6'
+  api 'com.google.android.gms:play-services-wearable:10.2.6'
 }
 
 apply from: rootProject.file('gradle/gradle-mvn-push.gradle')

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -6,19 +6,19 @@ apply plugin: 'com.getkeepsafe.dexcount'
 apply from: rootProject.file('gradle/android.gradle')
 
 dependencies {
-  compile rootProject.ext.deps.supportAnnotations
+  api rootProject.ext.deps.supportAnnotations
 
-  testCompile 'junit:junit:4.12'
-  testCompile('org.robolectric:robolectric:3.5') {
+  testImplementation 'junit:junit:4.12'
+  testImplementation('org.robolectric:robolectric:3.5') {
     exclude group: 'commons-logging', module: 'commons-logging'
     exclude group: 'org.apache.httpcomponents', module: 'httpclient'
   }
-  testCompile 'org.assertj:assertj-core:1.7.1'
-  testCompile 'com.squareup.assertj:assertj-android:1.1.1'
-  testCompile 'org.mockito:mockito-core:1.10.19'
-  testCompile 'com.squareup.okio:okio:1.10.0'
-  testCompile 'com.squareup.okhttp:mockwebserver:2.3.0'
-  testCompile 'com.squareup.burst:burst-junit4:1.1.1'
+  testImplementation 'org.assertj:assertj-core:1.7.1'
+  testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
+  testImplementation 'org.mockito:mockito-core:1.10.19'
+  testImplementation 'com.squareup.okio:okio:1.10.0'
+  testImplementation 'com.squareup.okhttp:mockwebserver:2.3.0'
+  testImplementation 'com.squareup.burst:burst-junit4:1.1.1'
 }
 
 apply from: rootProject.file('gradle/attach-jar.gradle')


### PR DESCRIPTION
Ref: https://segment.atlassian.net/browse/LIB-190

As noted in LIB-90, this fixes warnings like:

```
Configuration 'compile' in project ':analytics' is deprecated. Use 'implementation' instead.
Configuration 'testCompile' in project ':analytics' is deprecated. Use 'testImplementation' instead.
The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.
```

General rule here was:

* testCompile -> testImplementation since tests are not exported
* compile -> api in library since they are exported
* compile -> implementation in apps since they are not exported