### PR TITLE
Update test dependencies

### DIFF
--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -13,12 +13,16 @@ dependencies {
     exclude group: 'commons-logging', module: 'commons-logging'
     exclude group: 'org.apache.httpcomponents', module: 'httpclient'
   }
-  testImplementation 'org.assertj:assertj-core:1.7.1'
   testImplementation 'com.squareup.assertj:assertj-android:1.1.1'
   testImplementation 'org.mockito:mockito-core:1.10.19'
-  testImplementation 'com.squareup.okio:okio:1.10.0'
+  testImplementation 'com.squareup.okio:okio:1.13.0'
   testImplementation 'com.squareup.okhttp:mockwebserver:2.3.0'
   testImplementation 'com.squareup.burst:burst-junit4:1.1.1'
+
+  // We're intentionally on assertj 1.7.1 as the latest (3.8.0 as of 22/12/2017) is not compatible
+  // with Android.
+  //noinspection GradleDependency
+  testImplementation 'org.assertj:assertj-core:1.7.1'
 }
 
 apply from: rootProject.file('gradle/attach-jar.gradle')


### PR DESCRIPTION
Ref: https://segment.atlassian.net/browse/LIB-191

Fixes the warnings:

```
> Task :analytics:lint
Ran lint on variant release: 2 issues found
Ran lint on variant debug: 2 issues found
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/build.gradle:16: Warning: A newer version of org.assertj:assertj-core than 1.7.1 is available: 3.8.0 [GradleDependency]
  testImplementation 'org.assertj:assertj-core:1.7.1'
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/build.gradle:19: Warning: A newer version of com.squareup.okio:okio than 1.10.0 is available: 1.13.0 [GradleDependency]
  testImplementation 'com.squareup.okio:okio:1.10.0'
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "GradleDependency":
   This detector looks for usages of libraries where the version you are using
   is not the current stable release. Using older versions is fine, and there
   are cases where you deliberately want to stick with an older version.
   However, you may simply not be aware that a more recent version is
   available, and that is what this lint check helps find.

```

Intentionally using an older version of assertj, so suppressing the warning for it.