### PR TITLE
Fix lint warnings.

### DIFF
--- a/analytics-samples/analytics-sample/src/main/res/values/styles.xml
+++ b/analytics-samples/analytics-sample/src/main/res/values/styles.xml
@@ -22,7 +22,7 @@
   ~ SOFTWARE.
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
   <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
     <item name="android:textViewStyle">@style/AppTheme.Widget.TextView</item>
@@ -38,7 +38,8 @@
     <item name="fontPath">fonts/Aleo-Regular.otf</item>
   </style>
 
-  <style name="AppTheme.Widget"/>
+  <!-- This is an parent for AppTheme.Widget.TextView. It's empty, but it is definitely used. -->
+  <style name="AppTheme.Widget" tools:ignore="UnusedResources"/>
 
   <style name="AppTheme.Widget.TextView" parent="android:Widget.Holo.Light.TextView">
     <item name="fontPath">fonts/CircularStd-Book.otf</item>

--- a/analytics-samples/analytics-wear-sample/src/main/AndroidManifest.xml
+++ b/analytics-samples/analytics-wear-sample/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
 
     <meta-data android:name="com.google.android.gms.version"
         android:value="@integer/google_play_services_version"/>
+    <meta-data
+      android:name="com.google.android.wearable.standalone"
+      android:value="false"/>
 
   </application>
 


### PR DESCRIPTION
The first one can't be fixed until ButterKnife v9 is released.

Ref: https://segment.atlassian.net/browse/LIB-192

Fixes warnings:

```
> Task :analytics-samples:analytics-sample:lint
Ran lint on variant debug: 2 issues found
Ran lint on variant release: 2 issues found
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics-samples/analytics-sample: Warning: Lint found one or more custom checks using its older Java API; these checks are still run in compatibility mode, but this causes duplicated parsing, and in the next version lint will no longer include this legacy mode. Make sure the following lint detectors are upgraded to the new API: butterknife.lint.InvalidR2UsageDetector [ObsoleteLintCustomCheck]

   Explanation for issues of type "ObsoleteLintCustomCheck":
   Lint can be extended with "custom checks": additional checks implemented by
   developers and libraries to for example enforce specific API usages
   required by a library or a company coding style guideline.

   The Lint APIs are not yet stable, so these checks may either cause a
   performance, degradation, or stop working, or provide wrong results.

   This warning flags custom lint checks that are found to be using obsolete
   APIs and will need to be updated to run in the current lint environment.

/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics-samples/analytics-sample/src/main/res/values/styles.xml:41: Warning: The resource R.style.AppTheme_Widget appears to be unused [UnusedResources]
  <style name="AppTheme.Widget"/>
         ~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "UnusedResources":
   Unused resources make applications larger and slow down builds.

0 errors, 2 warnings
Wrote HTML report to file:///Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics-samples/analytics-sample/build/reports/lint-results.html
Wrote XML report to file:///Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics-samples/analytics-sample/build/reports/lint-results.xml

> Task :analytics-samples:analytics-wear-sample:lint
Ran lint on variant release: 1 issues found
Ran lint on variant debug: 1 issues found
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics-samples/analytics-wear-sample/src/main/AndroidManifest.xml:7: Warning: Missing <meta-data android:name="com.google.android.wearable.standalone" ../> element [WearStandaloneAppFlag]
  <application
  ^

   Explanation for issues of type "WearStandaloneAppFlag":
   Wearable apps should specify whether they can work standalone, without a
   phone app.Add a valid meta-data entry for
   com.google.android.wearable.standalone to your application element and set
   the value to true or false.
   <meta-data android:name="com.google.android.wearable.standalone"
               android:value="true"/>

   https://developer.android.com/training/wearables/apps/packaging.html

```