### PR TITLE
Fix JavaDoc warnings

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -488,7 +488,7 @@ public class Analytics {
    * @param newTraits Traits about the user.
    * @param options To configure the call.
    * @throws IllegalArgumentException if both {@code userId} and {@code newTraits} are not provided
-   * @see <a href="https://segment.com/docs/spec/identify/">Identify Documentation</a>.
+   * @see <a href="https://segment.com/docs/spec/identify/">Identify Documentation</a>
    */
   public void identify(
       @Nullable String userId, @Nullable Traits newTraits, final @Nullable Options options) {

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -553,7 +553,7 @@ public class AnalyticsContext extends ValueMap {
       return putValue(REFERRER_URL_KEY, url);
     }
 
-    /** @Set the referrer url. */
+    /** Set the referrer url. */
     public Referrer putUrl(String url) {
       return putValue(REFERRER_URL_KEY, url);
     }

--- a/analytics/src/main/java/com/segment/analytics/Options.java
+++ b/analytics/src/main/java/com/segment/analytics/Options.java
@@ -82,7 +82,7 @@ public class Options {
    * @param bundledIntegration The target integration
    * @param enabled <code>true</code> for enabled, <code>false</code> for disabled
    * @return This options object for chaining
-   * @see {@link Options#setIntegration(String, boolean)}
+   * @see #setIntegration(String, boolean)
    */
   public Options setIntegration(Analytics.BundledIntegration bundledIntegration, boolean enabled) {
     setIntegration(bundledIntegration.key, enabled);

--- a/analytics/src/main/java/com/segment/analytics/integrations/Integration.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/Integration.java
@@ -65,7 +65,7 @@ public abstract class Integration<T> {
 
   /**
    * @see Analytics#screen(String, String, com.segment.analytics.Properties,
-   *     com.segment.analytics.Options)}
+   *     com.segment.analytics.Options)
    */
   public void screen(ScreenPayload screen) {}
 

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -216,3 +216,8 @@ afterEvaluate { project ->
     }
   }
 }
+
+// Ref: https://github.com/chrisbanes/gradle-mvn-push/issues/39#issue-42709896
+afterEvaluate {
+  androidJavadocs.classpath += project.android.libraryVariants.toList().first().javaCompile.classpath
+}


### PR DESCRIPTION
Previously we'd get a lot of warnings like:

```
  symbol:   class Nullable
  location: class Analytics
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:604: error: cannot find symbol
      final @NonNull String event,
             ^
  symbol:   class NonNull
  location: class Analytics
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:605: error: cannot find symbol
      final @Nullable Properties properties,
             ^
  symbol:   class Nullable
  location: class Analytics
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:606: error: cannot find symbol
      @Nullable final Options options) {
       ^
  symbol:   class Nullable
  location: class Analytics
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:641: error: cannot find symbol
  public void screen(@Nullable String category, @Nullable String name) {
                      ^
  symbol:   class Nullable
  location: class Analytics
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:641: error: cannot find symbol
  public void screen(@Nullable String category, @Nullable String name) {
                                                 ^
  symbol:   class Nullable
  location: class Analytics
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:650: error: cannot find symbol
      @Nullable String category, @Nullable String name, @Nullable Properties properties) {
       ^
  symbol:   class Nullable
  location: class Analytics
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:650: error: cannot find symbol
      @Nullable String category, @Nullable String name, @Nullable Properties properties) {

```

I fixed these based on  https://github.com/chrisbanes/gradle-mvn-push/issues/39#issue-42709896. This made the output less noisy and surfaced some real bugs in the current javadocs.

```

> Task :analytics:androidJavadocs
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java:53: error: package com.segment.analytics.core does not exist
import com.segment.analytics.core.BuildConfig;
                                 ^
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Analytics.java:493: warning - Tag @see: missing final '>': "<a href="https://segment.com/docs/spec/identify/">Identify Documentation</a>."
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java:557: warning - @Set is an unknown tag.
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Options.java:87: warning - Tag @see:illegal character: "123" in "{@link Options#setIntegration(String, boolean)}"
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Options.java:87: warning - Tag @see:illegal character: "64" in "{@link Options#setIntegration(String, boolean)}"
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/Options.java:87: warning - Tag @see: reference not found: {@link Options#setIntegration(String, boolean)}
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/integrations/Integration.java:70: warning - Tag @see:illegal character: "125" in "Analytics#screen(String, String, com.segment.analytics.Properties,
     com.segment.analytics.Options)}"
7 warnings

```

I was able to fix almost all of these. Now only the first one is left:

```

> Task :analytics:androidJavadocs
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java:53: error: package com.segment.analytics.core does not exist
import com.segment.analytics.core.BuildConfig;
                                 ^
1 warning

```

It's unclear how to fix this one given that the BuildConfig file is generated during the build process.= and not written by us.