### PR TITLE
Fix Runscope Token escaping when not set.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Copy E2E Test Credentials
           command: |
             if [ "${RUN_E2E_TESTS}" == "true" ]; then
-              echo "RUNSCOPE_TOKEN=\"${RUNSCOPE_TOKEN}\"" >> "analytics-samples/analytics-sample/e2e_test.properties"
+              echo "RUNSCOPE_TOKEN=${RUNSCOPE_TOKEN}" >> "analytics-samples/analytics-sample/e2e_test.properties"
             fi
       - run:
           name: Build

--- a/analytics-samples/analytics-sample/build.gradle
+++ b/analytics-samples/analytics-sample/build.gradle
@@ -6,7 +6,7 @@ apply from: rootProject.file('gradle/android.gradle')
 def RUNSCOPE_TOKEN = ""
 def RUN_E2E_TESTS = false
 
-// e2e_test.properties is a file with a single line: RUNSCOPE_TOKEN="<token>"
+// e2e_test.properties is a file with a single line: RUNSCOPE_TOKEN=<token>
 def e2eTestPropertiesFile = file('e2e_test.properties')
 if (e2eTestPropertiesFile.exists()) {
   def props = new Properties()
@@ -24,7 +24,7 @@ android {
   defaultConfig {
     testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
-    buildConfigField 'String', 'RUNSCOPE_TOKEN', "$RUNSCOPE_TOKEN"
+    buildConfigField 'String', 'RUNSCOPE_TOKEN', "\"$RUNSCOPE_TOKEN\""
     buildConfigField 'boolean', 'RUN_E2E_TESTS', "$RUN_E2E_TESTS"
   }
 }


### PR DESCRIPTION
When folks don't want to set the Runscope token (e.g. contributors), we were not escaping the keys. This would cause the generated code to be invalid:

```
public static final String RUNSCOPE_TOKEN = ;
```

This causes compilation to fail with the error https://cl.ly/0Z2d101g2y0m.

To fix this, we tweak how the token is rendererd, and always wrap it with quotes. Tweaked the CI config to not wrap the token in quotes in the properties file.

Ref: LIB-221