### PR TITLE
Set the userId on the analytics executor thread.

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -491,27 +491,29 @@ public class Analytics {
    * @see <a href="https://segment.com/docs/spec/identify/">Identify Documentation</a>
    */
   public void identify(
-      @Nullable String userId, @Nullable Traits newTraits, final @Nullable Options options) {
+      final @Nullable String userId,
+      final @Nullable Traits newTraits,
+      final @Nullable Options options) {
     assertNotShutdown();
     if (isNullOrEmpty(userId) && isNullOrEmpty(newTraits)) {
       throw new IllegalArgumentException("Either userId or some traits must be provided.");
     }
 
-    Traits traits = traitsCache.get();
-    if (!isNullOrEmpty(userId)) {
-      traits.putUserId(userId);
-    }
-    if (!isNullOrEmpty(newTraits)) {
-      traits.putAll(newTraits);
-    }
-
-    traitsCache.set(traits); // Save the new traits
-    analyticsContext.setTraits(traits); // Update the references
-
     analyticsExecutor.submit(
         new Runnable() {
           @Override
           public void run() {
+            Traits traits = traitsCache.get();
+            if (!isNullOrEmpty(userId)) {
+              traits.putUserId(userId);
+            }
+            if (!isNullOrEmpty(newTraits)) {
+              traits.putAll(newTraits);
+            }
+
+            traitsCache.set(traits); // Save the new traits
+            analyticsContext.setTraits(traits); // Update the references
+
             final Options finalOptions;
             if (options == null) {
               finalOptions = defaultOptions;


### PR DESCRIPTION
Previously we were setting the userId on the thread that `identify` is called (which may be any thread), but reading the userId on a background thread.

Because of this, the userId on events called before identify may have the userId from "newer" events.

```
analytics.identify("foo");
analytics.track("event"); -> may have userId foo
analytics.identify("bar");
```

To fix this, we now also set the userId on the background thread.

Originally referenced in https://github.com/segmentio/analytics-android/issues/522. Note that my original solution proposed we read the userId on the main thread to fix the issue, but the fix implemented here is to read the userId on the background thread instead.

Ref: LIB-120

Closes #522