### PR TITLE
Collect `context.app.build` as a string.

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -209,7 +209,7 @@ public class AnalyticsContext extends ValueMap {
       putUndefinedIfNull(app, APP_NAME_KEY, packageInfo.applicationInfo.loadLabel(packageManager));
       putUndefinedIfNull(app, APP_VERSION_KEY, packageInfo.versionName);
       putUndefinedIfNull(app, APP_NAMESPACE_KEY, packageInfo.packageName);
-      app.put(APP_BUILD_KEY, packageInfo.versionCode);
+      app.put(APP_BUILD_KEY, String.valueOf(packageInfo.versionCode));
       put(APP_KEY, app);
     } catch (PackageManager.NameNotFoundException e) {
       // ignore

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -53,7 +53,7 @@ public class AnalyticsContextTest {
         .containsEntry("name", "org.robolectric.default")
         .containsEntry("version", "undefined")
         .containsEntry("namespace", "org.robolectric.default")
-        .containsEntry("build", 0);
+        .containsEntry("build", "0");
 
     assertThat(context.getValueMap("device")) //
         .containsEntry("id", "unknown")


### PR DESCRIPTION
From https://github.com/segmentio/analytics-android/issues/481:

> The app_build_key is added to the context as an integer, as opposed to a string. This differs from OS libraries, and the general representation of context app fields as a dictionary with string values (see segment)

This is a somewhat breaking change for consumers of the field. Previously they would see a number, but now they'll see a string. Ultimately I think consistency across the libraries is better, and we'll call out this change in the changelog.

Ref: LIB-123

Closes https://github.com/segmentio/analytics-android/issues/481