### PR TITLE
Update message size limit to be 32kb.

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
+++ b/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
@@ -69,13 +69,13 @@ class SegmentIntegration extends Integration<Void> {
       };
 
   /**
-   * Drop old payloads if queue contains more than 1000 items. Since each item can be at most 15KB,
-   * this bounds the queue size to ~15MB (ignoring headers), which also leaves room for QueueFile's
+   * Drop old payloads if queue contains more than 1000 items. Since each item can be at most 32KB,
+   * this bounds the queue size to ~32MB (ignoring headers), which also leaves room for QueueFile's
    * 2GB limit.
    */
   static final int MAX_QUEUE_SIZE = 1000;
-  /** Our servers only accept payloads < 15KB. */
-  static final int MAX_PAYLOAD_SIZE = 15000; // 15KB.
+  /** Our servers only accept payloads < 32KB. */
+  static final int MAX_PAYLOAD_SIZE = 32000; // 32KB.
   /**
    * Our servers only accept batches < 500KB. This limit is 475KB to account for extra data that is
    * not present in payloads themselves, but is added later, such as {@code sentAt}, {@code

--- a/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
+++ b/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
@@ -355,7 +355,7 @@ public class SegmentIntegrationTest {
     segmentIntegration.performEnqueue(payload);
     verify(payloadQueue, never()).add((byte[]) any());
 
-    // Serialized json is too large (> 15kb).
+    // Serialized json is too large (> MAX_PAYLOAD_SIZE).
     StringBuilder stringBuilder = new StringBuilder();
     for (int i = 0; i < SegmentIntegration.MAX_PAYLOAD_SIZE + 1; i++) {
       stringBuilder.append("a");


### PR DESCRIPTION
We've changed the maximum message size from to 32kb —  https://github.com/segmentio/api-validator/commit/ba561c3acc27c26ac9a55549964ffd8f17a54d6c. This is also documented at https://segment.com/docs/sources/server/http/#max-request-size.

Ref: https://segment.atlassian.net/browse/LIB-225