### PR TITLE
Retry HTTP 429 Errors

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Client.java
+++ b/analytics/src/main/java/com/segment/analytics/Client.java
@@ -120,6 +120,10 @@ class Client {
       this.responseMessage = responseMessage;
       this.responseBody = responseBody;
     }
+
+    boolean is4xx() {
+      return responseCode >= 400 && responseCode < 500;
+    }
   }
 
   /**

--- a/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
+++ b/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
@@ -354,7 +354,7 @@ class SegmentIntegration extends Integration<Void> {
       // Upload the payloads.
       connection.close();
     } catch (Client.HTTPException e) {
-      if (e.responseCode >= 400 && e.responseCode < 500) {
+      if (e.is4xx() && e.responseCode != 429) {
         // Simply log and proceed to remove the rejected payloads from the queue.
         logger.error(e, "Payloads were rejected by server. Marked for removal.");
         try {


### PR DESCRIPTION
As per the library guidelines, our retry policy should be:

1. Retry network errors (socket timed out, etc.)
2. Retry server errors (HTTP 5xx)
3. Do not retry client errors (HTTP 4xx)
  1. Except HTTP 429.

We weren't handling the HTTP 429 case correctly. This PR updates the retry logic to correctly handle this case. This shouldn't matter too much in practice immediately because we don't serve this status code currently, but is good to have to future proof the library.

Ref: https://paper.dropbox.com/doc/Analytics-library-guidelines-2trBhLKQD4Soz4VatvuGR#:uid=189560039280582553736180&h2=Handling-Network-Errors

Ref: https://segment.atlassian.net/browse/LIB-379