### PR TITLE
replace problematic characters

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -255,7 +255,7 @@ public class Analytics {
           public void run() {
             projectSettings = getSettings();
             if (isNullOrEmpty(projectSettings)) {
-              // Backup mode — Enable just the Segment integration.
+              // Backup mode - Enable just the Segment integration.
               // {
               //   integrations: {
               //     Segment.io: {

--- a/analytics/src/main/java/com/segment/analytics/Properties.java
+++ b/analytics/src/main/java/com/segment/analytics/Properties.java
@@ -95,7 +95,7 @@ public class Properties extends ValueMap {
 
   /**
    * Set an abstract value to associate with an event. This is typically used in situations where
-   * the event doesn’t generate real-dollar revenue, but has an intrinsic value to a marketing team,
+   * the event doesn't generate real-dollar revenue, but has an intrinsic value to a marketing team,
    * like newsletter signups.
    */
   public Properties putValue(double value) {
@@ -186,7 +186,7 @@ public class Properties extends ValueMap {
   }
 
   /**
-   * Set a category for this action. You’ll want to track all of your product category pages so you
+   * Set a category for this action. You'll want to track all of your product category pages so you
    * can quickly see which categories are most popular.
    *
    * @see <a href="https://segment.com/docs/api/tracking/ecommerce/">Ecommerce API</a>

--- a/analytics/src/main/java/com/segment/analytics/Traits.java
+++ b/analytics/src/main/java/com/segment/analytics/Traits.java
@@ -173,7 +173,7 @@ public class Traits extends ValueMap {
   }
 
   /**
-   * Set the date the user’s or group’s account was first created. We accept date objects and a wide
+   * Set the date the user's or group's account was first created. We accept date objects and a wide
    * range of date formats, including ISO strings and Unix timestamps. Feel free to use whatever
    * format is easiest for you - although ISO string is recommended for Android.
    */
@@ -310,7 +310,7 @@ public class Traits extends ValueMap {
   }
 
   /**
-   * Set the user’s username. This should be unique to each user, like the usernames of Twitter or
+   * Set the user's username. This should be unique to each user, like the usernames of Twitter or
    * GitHub.
    */
   public Traits putUsername(String username) {

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -295,7 +295,7 @@ public abstract class BasePayload extends ValueMap {
     }
 
     /**
-     * The Anonymous ID is a pseudo-unique substitute for a User ID, for cases when you don’t have
+     * The Anonymous ID is a pseudo-unique substitute for a User ID, for cases when you don't have
      * an absolutely unique identifier.
      *
      * @see <a href="https://segment.com/docs/spec/identify/#identities">Identities</a>

--- a/analytics/src/main/java/com/segment/analytics/internal/Iso8601Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Iso8601Utils.java
@@ -23,7 +23,7 @@ import java.util.Locale;
 import java.util.TimeZone;
 
 /**
- * Jackson’s date formatter, pruned to Moshi's needs. Forked from this file:
+ * Jackson's date formatter, pruned to Moshi's needs. Forked from this file:
  * https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/util/ISO8601Utils.java
  *
  * <p>Utilities methods for manipulating dates in iso8601 format. This is much much faster and GC


### PR DESCRIPTION
These characters cause compilation to fail locally on my machine.

```
>>>  ./gradlew clean build

> Configure project :analytics
The ConfigurableReport.setDestination(Object) method has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the method ConfigurableReport.setDestination(File) instead.

> Task :analytics:androidJavadocs
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/internal/Iso8601Utils.java:26: error: unmappable character for encoding ASCII
 * Jackson???s date formatter, pruned to Moshi's needs. Forked from this file:
          ^
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/internal/Iso8601Utils.java:26: error: unmappable character for encoding ASCII
 * Jackson???s date formatter, pruned to Moshi's needs. Forked from this file:
           ^
/Users/prateek/dev/src/github.com/segmentio/analytics-android/analytics/src/main/java/com/segment/analytics/internal/Iso8601Utils.java:26: error: unmappable character for encoding ASCII
 * Jackson???s date formatter, pruned to Moshi's needs. Forked from this file:

```

Replacing these characters fixes the problem locally. I didn't have much luck fixing this in the gradle config directly, and this doesn't fail in CI, so it's likely this is due to a local setup issue, but it's not clear what the issue is.