### PR TITLE
    Send RFC 7231 Formatted User Agent

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/ConnectionFactory.java
+++ b/analytics/src/main/java/com/segment/analytics/ConnectionFactory.java
@@ -1,6 +1,7 @@
 package com.segment.analytics;
 
 import android.util.Base64;
+import com.segment.analytics.core.BuildConfig;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -13,6 +14,7 @@ public class ConnectionFactory {
 
   private static final int DEFAULT_READ_TIMEOUT_MILLIS = 20 * 1000; // 20s
   private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 15 * 1000; // 15s
+  static final String USER_AGENT = "analytics-android/" + BuildConfig.VERSION_NAME;
 
   private String authorizationHeader(String writeKey) {
     return "Basic " + Base64.encodeToString((writeKey + ":").getBytes(), Base64.NO_WRAP);
@@ -58,6 +60,7 @@ public class ConnectionFactory {
     connection.setConnectTimeout(DEFAULT_CONNECT_TIMEOUT_MILLIS);
     connection.setReadTimeout(DEFAULT_READ_TIMEOUT_MILLIS);
     connection.setRequestProperty("Content-Type", "application/json");
+    connection.setRequestProperty("User-Agent", USER_AGENT);
     connection.setDoInput(true);
     return connection;
   }

--- a/analytics/src/test/java/com/segment/analytics/ClientTest.java
+++ b/analytics/src/test/java/com/segment/analytics/ClientTest.java
@@ -75,6 +75,7 @@ public class ClientTest {
     assertThat(connection.connection.getResponseCode()).isEqualTo(200); // consume the response.
     RecordedRequestAssert.assertThat(server.takeRequest())
         .hasRequestLine("POST /v1/import HTTP/1.1")
+        .containsHeader("User-Agent", ConnectionFactory.USER_AGENT)
         .containsHeader("Content-Type", "application/json")
         .containsHeader("Content-Encoding", "gzip")
         .containsHeader("Authorization", "Basic Zm9vOg==");
@@ -90,6 +91,7 @@ public class ClientTest {
     assertThat(connection.connection.getResponseCode()).isEqualTo(200); // consume the response.
     RecordedRequestAssert.assertThat(server.takeRequest())
         .hasRequestLine("POST /v1/attribution HTTP/1.1")
+        .containsHeader("User-Agent", ConnectionFactory.USER_AGENT)
         .containsHeader("Content-Type", "application/json")
         .containsHeader("Authorization", "Basic Zm9vOg==");
   }
@@ -170,10 +172,10 @@ public class ClientTest {
       fail(">= 300 return code should throw an exception");
     } catch (Client.HTTPException e) {
       assertThat(e)
-              .hasMessage(
-                      "HTTP 404: bar. "
-                              + "Response: Could not read response body for rejected message: "
-                              + "java.io.IOException: Underlying input stream returned zero bytes");
+          .hasMessage(
+              "HTTP 404: bar. "
+                  + "Response: Could not read response body for rejected message: "
+                  + "java.io.IOException: Underlying input stream returned zero bytes");
     }
     verify(mockConnection).disconnect();
     verify(os).close();
@@ -189,6 +191,7 @@ public class ClientTest {
     assertThat(connection.connection.getResponseCode()).isEqualTo(200);
     RecordedRequestAssert.assertThat(server.takeRequest())
         .hasRequestLine("GET /v1/projects/foo/settings HTTP/1.1")
+        .containsHeader("User-Agent", ConnectionFactory.USER_AGENT)
         .containsHeader("Content-Type", "application/json");
   }
 


### PR DESCRIPTION
    As per the library guidelines, we want to send a custom user agent for all requests from this library.

    https://paper.dropbox.com/doc/Analytics-library-guidelines-2trBhLKQD4Soz4VatvuGR#:uid=631141099033910690508560&h2=User-Agent

    The header is sent in the format analytics-android/<version>, where version is the same version sent in context.library.version for events.

    Ref: https://segment.atlassian.net/browse/LIB-381