### PR TITLE
Fix broken build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
   repositories {
     mavenCentral()
-    jcenter()
     google()
+    jcenter()
     maven {
       url 'https://plugins.gradle.org/m2/'
     }
@@ -20,8 +20,8 @@ allprojects {
   buildscript {
     repositories {
       mavenCentral()
-      jcenter()
       google()
+      jcenter()
     }
   }
 
@@ -29,8 +29,8 @@ allprojects {
 
   repositories {
     mavenCentral()
-    jcenter()
     google()
+    jcenter()
   }
 
   group = GROUP


### PR DESCRIPTION
Currently fresh builds are failing with the following error:

```
A problem occurred configuring root project 'analytics-android'.
> Could not resolve all files for configuration ':classpath'.
   > Could not find lint-gradle-api.jar (com.android.tools.lint:lint-gradle-api:26.1.2).
     Searched in the following locations:
         https://jcenter.bintray.com/com/android/tools/lint/lint-gradle-api/26.1.2/lint-gradle-api-26.1.2.jar
```

e.g. https://circleci.com/gh/segmentio/analytics-android/2896

The Gradle plugin scans all your repositories to find a dependency. However,  due to a bug in jcenter, it incorrectly signals to Gradle that it owns the dependency (even when it doesn't) and causes Gradle to stop looking further.

The fix is to move jcenter to last so that it cannot incorrectly claim the dependency before other repositories.