### PR TITLE
Add settings to middlewares

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -1298,9 +1298,7 @@ public class Analytics {
       return this;
     }
 
-    /**
-     * The ProjectSettings cache for storing settings. This is not exposed publicly.
-     */
+    /** The ProjectSettings cache for storing settings. This is not exposed publicly. */
     Builder projectSettingsCache(ProjectSettings.Cache projectSettingsCache) {
       this.projectSettingsCache = assertNotNull(projectSettingsCache, "projectSettingsCache");
       return this;

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -1089,6 +1089,7 @@ public class Analytics {
     private boolean recordScreenViews = false;
     private boolean trackAttributionInformation = false;
     private Crypto crypto;
+    private ProjectSettings.Cache projectSettingsCache;
 
     /** Start building a new {@link Analytics} instance. */
     public Builder(Context context, String writeKey) {
@@ -1297,6 +1298,14 @@ public class Analytics {
       return this;
     }
 
+    /**
+     * The ProjectSettings cache for storing settings. This is not exposed publicly.
+     */
+    Builder projectSettingsCache(ProjectSettings.Cache projectSettingsCache) {
+      this.projectSettingsCache = assertNotNull(projectSettingsCache, "projectSettingsCache");
+      return this;
+    }
+
     /** Create a {@link Analytics} client. */
     public Analytics build() {
       if (isNullOrEmpty(tag)) {
@@ -1333,8 +1342,10 @@ public class Analytics {
       final Cartographer cartographer = Cartographer.INSTANCE;
       final Client client = new Client(writeKey, connectionFactory);
 
-      ProjectSettings.Cache projectSettingsCache =
-          new ProjectSettings.Cache(application, cartographer, tag);
+      ProjectSettings.Cache projectSettingsCache = this.projectSettingsCache;
+      if (projectSettingsCache == null) {
+        projectSettingsCache = new ProjectSettings.Cache(application, cartographer, tag);
+      }
 
       BooleanPreference optOut =
           new BooleanPreference(

--- a/analytics/src/main/java/com/segment/analytics/Middleware.java
+++ b/analytics/src/main/java/com/segment/analytics/Middleware.java
@@ -24,6 +24,7 @@
 package com.segment.analytics;
 
 import com.segment.analytics.integrations.BasePayload;
+import com.segment.analytics.ProjectSettings;
 
 /** Middlewares run for every message after it is built to process it further. */
 public interface Middleware {
@@ -34,6 +35,7 @@ public interface Middleware {
   interface Chain {
 
     BasePayload payload();
+    ProjectSettings settings();
 
     void proceed(BasePayload payload);
   }

--- a/analytics/src/main/java/com/segment/analytics/Middleware.java
+++ b/analytics/src/main/java/com/segment/analytics/Middleware.java
@@ -24,7 +24,6 @@
 package com.segment.analytics;
 
 import com.segment.analytics.integrations.BasePayload;
-import com.segment.analytics.ProjectSettings;
 
 /** Middlewares run for every message after it is built to process it further. */
 public interface Middleware {
@@ -35,6 +34,7 @@ public interface Middleware {
   interface Chain {
 
     BasePayload payload();
+
     ProjectSettings settings();
 
     void proceed(BasePayload payload);

--- a/analytics/src/main/java/com/segment/analytics/RealMiddlewareChain.java
+++ b/analytics/src/main/java/com/segment/analytics/RealMiddlewareChain.java
@@ -51,6 +51,11 @@ class RealMiddlewareChain implements Middleware.Chain {
   }
 
   @Override
+  public ProjectSettings settings() {
+    return analytics.getSettings();
+  }
+
+  @Override
   public void proceed(BasePayload payload) {
     // If there's another middleware in the chain, call that.
     if (index < middlewares.size()) {

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.java
@@ -89,6 +89,16 @@ public class AnalyticsBuilderTest {
   }
 
   @Test
+  public void invalidProjectSettingsCacheThrowsException() throws Exception {
+    try {
+      new Builder(context, "foo").projectSettingsCache(null);
+      fail("Null projectSettingsCache should throw exception.");
+    } catch (NullPointerException expected) {
+      assertThat(expected).hasMessage("projectSettingsCache == null");
+    }
+  }
+
+  @Test
   public void invalidMiddlewareThrowsException() throws Exception {
     try {
       new Builder(context, "foo").middleware(null);

--- a/analytics/src/test/java/com/segment/analytics/MiddlewareTest.java
+++ b/analytics/src/test/java/com/segment/analytics/MiddlewareTest.java
@@ -25,8 +25,8 @@ package com.segment.analytics;
 
 import static com.segment.analytics.TestUtils.grantPermission;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.MockitoAnnotations.initMocks;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import android.Manifest;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -34,9 +34,9 @@ import com.segment.analytics.Analytics.Builder;
 import com.segment.analytics.integrations.BasePayload;
 import com.segment.analytics.integrations.ScreenPayload;
 import com.segment.analytics.integrations.TrackPayload;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
This change adds a new method to the `Chain` interface to retrieve the project settings in a middleware interceptor.

My use case is, we are creating a Adobe Marketing Cloud Visitior ID middleware and we need to make a request to an external HTTP API to retrieve and then inject the ID to Segment events. For that request, we need the value of the Organization ID (a setting already present and rendered on CDN).

Please let me know if this makes sense. If not, the customer using the middleware needs to provide the Organization ID when instantiating the middleware.