### PR TITLE
Fixed error where post-shutdown, a flush would be executed and crash …

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -948,7 +948,10 @@ public class Analytics {
     }
   }
 
-  /** Stops this instance from accepting further requests. */
+  /**
+   * Stops this instance from accepting further requests. In-flight events may not be uploaded right
+   * away.
+   */
   public void shutdown() {
     if (this == singleton) {
       throw new UnsupportedOperationException("Default singleton instance cannot be shutdown.");

--- a/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
+++ b/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
@@ -334,15 +334,17 @@ class SegmentIntegration extends Integration<Void> {
       return;
     }
 
-    networkExecutor.submit(
-        new Runnable() {
-          @Override
-          public void run() {
-            synchronized (flushLock) {
-              performFlush();
-            }
-          }
-        });
+    if (!networkExecutor.isShutdown()) {
+      networkExecutor.submit(
+              new Runnable() {
+                @Override
+                public void run() {
+                  synchronized (flushLock) {
+                    performFlush();
+                  }
+                }
+              });
+    }
   }
 
   private boolean shouldFlush() {

--- a/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
+++ b/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
@@ -334,17 +334,21 @@ class SegmentIntegration extends Integration<Void> {
       return;
     }
 
-    if (!networkExecutor.isShutdown()) {
-      networkExecutor.submit(
-          new Runnable() {
-            @Override
-            public void run() {
-              synchronized (flushLock) {
-                performFlush();
-              }
-            }
-          });
+    if (networkExecutor.isShutdown()) {
+      logger.info(
+          "A call to flush() was made after shutdown() has been called.  In-flight events may not be uploaded right away.");
+      return;
     }
+
+    networkExecutor.submit(
+        new Runnable() {
+          @Override
+          public void run() {
+            synchronized (flushLock) {
+              performFlush();
+            }
+          }
+        });
   }
 
   private boolean shouldFlush() {

--- a/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
+++ b/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
@@ -336,14 +336,14 @@ class SegmentIntegration extends Integration<Void> {
 
     if (!networkExecutor.isShutdown()) {
       networkExecutor.submit(
-              new Runnable() {
-                @Override
-                public void run() {
-                  synchronized (flushLock) {
-                    performFlush();
-                  }
-                }
-              });
+          new Runnable() {
+            @Override
+            public void run() {
+              synchronized (flushLock) {
+                performFlush();
+              }
+            }
+          });
     }
   }
 

--- a/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
+++ b/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
@@ -73,7 +73,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.verification.VerificationMode;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
@@ -252,10 +251,10 @@ public class SegmentIntegrationTest {
     PayloadQueue payloadQueue = mock(PayloadQueue.class);
     when(payloadQueue.size()).thenReturn(1);
     SegmentIntegration dispatcher =
-            new SegmentBuilder() //
-                    .payloadQueue(payloadQueue)
-                    .networkExecutor(executor)
-                    .build();
+        new SegmentBuilder() //
+            .payloadQueue(payloadQueue)
+            .networkExecutor(executor)
+            .build();
 
     dispatcher.shutdown();
     executor.shutdown();
@@ -459,7 +458,6 @@ public class SegmentIntegrationTest {
     segmentIntegration.shutdown();
     segmentIntegration.submitFlush();
   }
-
 
   @Test
   public void payloadVisitorReadsOnly475KB() throws IOException {

--- a/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
+++ b/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
@@ -447,18 +447,7 @@ public class SegmentIntegrationTest {
 
     verify(payloadQueue).close();
   }
-
-  @Test
-  public void shutdownAndRestart() {
-    PayloadQueue payloadQueue = mock(PayloadQueue.class);
-    SegmentIntegration segmentIntegration = new SegmentBuilder().payloadQueue(payloadQueue).build();
-
-    segmentIntegration.performEnqueue(TRACK_PAYLOAD);
-
-    segmentIntegration.shutdown();
-    segmentIntegration.submitFlush();
-  }
-
+  
   @Test
   public void payloadVisitorReadsOnly475KB() throws IOException {
     SegmentIntegration.PayloadWriter payloadWriter =

--- a/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
+++ b/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.java
@@ -447,7 +447,7 @@ public class SegmentIntegrationTest {
 
     verify(payloadQueue).close();
   }
-  
+
   @Test
   public void payloadVisitorReadsOnly475KB() throws IOException {
     SegmentIntegration.PayloadWriter payloadWriter =


### PR DESCRIPTION
- Fixes an issue where the segment integration ends up calling submitFlush() after the network executor has been shutdown.  This would cause an exception.
- Added a test to verify that submitFlush() is not called if the network executor is stopped.
- Addresses LIB-621 and #616 
