### PR TITLE
Make Crypto abstract methods public

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Crypto.java
+++ b/analytics/src/main/java/com/segment/analytics/Crypto.java
@@ -27,19 +27,19 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 public abstract class Crypto {
-  abstract InputStream decrypt(InputStream is);
+  public abstract InputStream decrypt(InputStream is);
 
-  abstract OutputStream encrypt(OutputStream os);
+  public abstract OutputStream encrypt(OutputStream os);
 
   public static Crypto none() {
     return new Crypto() {
       @Override
-      InputStream decrypt(InputStream is) {
+      public InputStream decrypt(InputStream is) {
         return is;
       }
 
       @Override
-      OutputStream encrypt(OutputStream os) {
+      public OutputStream encrypt(OutputStream os) {
         return os;
       }
     };

--- a/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
+++ b/analytics/src/main/java/com/segment/analytics/SegmentIntegration.java
@@ -447,7 +447,8 @@ class SegmentIntegration extends Integration<Void> {
       byte[] data = new byte[length];
       //noinspection ResultOfMethodCallIgnored
       is.read(data, 0, length);
-      writer.emitPayloadObject(new String(data, UTF_8));
+      // Remove trailing whitespace.
+      writer.emitPayloadObject(new String(data, UTF_8).trim());
       payloadCount++;
       return true;
     }


### PR DESCRIPTION
It's not currently possible to plug in a custom `Crypto` implementation for storing analytics events on disk since these abstract methods have default / package visibility. 