### PR TITLE
Fix aliasing by ensuring userId in payload is not overridden by cached userId

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -739,9 +739,10 @@ public class Analytics {
     builder.context(contextCopy);
     builder.anonymousId(contextCopy.traits().anonymousId());
     builder.integrations(options.integrations());
-    String userId = contextCopy.traits().userId();
-    if (!isNullOrEmpty(userId)) {
-      builder.userId(userId);
+    String userId = builder.getUserId();
+    if (isNullOrEmpty(userId)) {
+      String cachedUserId = contextCopy.traits().userId();
+      builder.userId(cachedUserId);
     }
     enqueue(builder.build());
   }

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -318,6 +318,11 @@ public abstract class BasePayload extends ValueMap {
       return self();
     }
 
+    @Nullable
+    public String getUserId() {
+      return this.userId;
+    }
+
     abstract P realBuild(
         @NonNull String messageId,
         @NonNull Date timestamp,


### PR DESCRIPTION
This fixes issue #633 

Currently, if a userId is cached on a device (and therefore stored in `contextCopy.traits().userId()`), this breaks aliasing.

Since `builder.userId` is always set if a cached previous user id exists, it always overrides any new user id entered.

To fix this, a method was added to retrieve the userId from the payload. If a userId exists in the payload, the cached user id is not used. If a userId is not submitted in the payload (userId is null or empty), the cached userId is used to set `builder.userId`

