### PR TITLE
LIB-1574: Double-check that input stream is closed…

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Client.java
+++ b/analytics/src/main/java/com/segment/analytics/Client.java
@@ -58,7 +58,9 @@ class Client {
           if (responseCode >= 300) {
             String responseBody;
             try {
-              responseBody = readFully(getInputStream(connection));
+              InputStream inputStream = getInputStream(connection);
+              responseBody = readFully(inputStream);
+              inputStream.close();
             } catch (IOException e) {
               responseBody = "Could not read response body for rejected message: " + e.toString();
             }
@@ -146,8 +148,6 @@ class Client {
     @Override
     public void close() throws IOException {
       connection.disconnect();
-      is.close();
-      os.close();
     }
   }
 }

--- a/analytics/src/main/java/com/segment/analytics/Client.java
+++ b/analytics/src/main/java/com/segment/analytics/Client.java
@@ -146,6 +146,8 @@ class Client {
     @Override
     public void close() throws IOException {
       connection.disconnect();
+      is.close();
+      os.close();
     }
   }
 }

--- a/analytics/src/main/java/com/segment/analytics/Client.java
+++ b/analytics/src/main/java/com/segment/analytics/Client.java
@@ -57,12 +57,16 @@ class Client {
           int responseCode = connection.getResponseCode();
           if (responseCode >= 300) {
             String responseBody;
+            InputStream inputStream = null;
             try {
-              InputStream inputStream = getInputStream(connection);
+              inputStream = getInputStream(connection);
               responseBody = readFully(inputStream);
-              inputStream.close();
             } catch (IOException e) {
               responseBody = "Could not read response body for rejected message: " + e.toString();
+            } finally {
+              if (inputStream != null) {
+                inputStream.close();
+              }
             }
             throw new HTTPException(responseCode, connection.getResponseMessage(), responseBody);
           }


### PR DESCRIPTION
- Ensure that input stream is closed on a failure.  This appears to be a known issue with HttpURLConnection.
- Was not able to reproduce said issue, but this seems to follow community guidance in resolving the problem.
- Best attempt to fix #588 