### PR TITLE
Reproduce Lifecyce issue

### DIFF
--- a/analytics-samples/analytics-sample/build.gradle
+++ b/analytics-samples/analytics-sample/build.gradle
@@ -32,6 +32,9 @@ dependencies {
   implementation project(':analytics')
   implementation project(':analytics-wear')
 
+  implementation("android.arch.lifecycle:common:+")
+  implementation "android.arch.lifecycle:extensions:+"
+
   implementation 'uk.co.chrisjenx:calligraphy:2.2.0'
   implementation 'com.jakewharton:butterknife:8.8.1'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.1'

--- a/analytics-samples/analytics-sample/src/main/AndroidManifest.xml
+++ b/analytics-samples/analytics-sample/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
       android:theme="@style/AppTheme"
       android:name=".SampleApp">
 
+    <activity android:name=".SecondActivity"></activity>
     <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/MainActivity.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/MainActivity.java
@@ -24,12 +24,18 @@
 package com.segment.analytics.sample;
 
 import android.app.Activity;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.arch.lifecycle.ProcessLifecycleOwner;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.EditText;
@@ -57,6 +63,14 @@ public class MainActivity extends Activity {
     ButterKnife.bind(this);
 
     SampleApp.initSegmentLazy(this);
+
+    //This is only a test of ProcessLifecycleOwner, to verify that it properly goes through onCreate>onStart>onResume even after the activity is already created
+    ProcessLifecycleOwner.get().getLifecycle().addObserver(new LifecycleObserver() {
+      @OnLifecycleEvent(Lifecycle.Event.ON_ANY)
+      public void onEvent(LifecycleOwner owner, Lifecycle.Event event) {
+        Log.d("LifecycleObserver", "onEvent: " + event);
+      }
+    });
   }
 
   @OnClick(R.id.action_track_a)

--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/MainActivity.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/MainActivity.java
@@ -55,6 +55,8 @@ public class MainActivity extends Activity {
 
     setContentView(R.layout.activity_main);
     ButterKnife.bind(this);
+
+    SampleApp.initSegmentLazy(this);
   }
 
   @OnClick(R.id.action_track_a)

--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/MainActivity.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/MainActivity.java
@@ -67,6 +67,7 @@ public class MainActivity extends Activity {
   @OnClick(R.id.action_track_b)
   void onButtonBClicked() {
     Analytics.with(this).track("Button B Clicked");
+    startActivity(new Intent(this, SecondActivity.class));
   }
 
   @OnClick(R.id.action_identify)

--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
@@ -24,6 +24,7 @@
 package com.segment.analytics.sample;
 
 import android.app.Application;
+import android.content.Context;
 import android.util.Log;
 import com.segment.analytics.Analytics;
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
@@ -42,19 +43,25 @@ public class SampleApp extends Application {
             .setDefaultFontPath("fonts/CircularStd-Book.otf")
             .setFontAttrId(R.attr.fontPath)
             .build());
+  }
+
+  private static boolean isInitAlready = false;
+  public static void initSegmentLazy(Context context) {
+    if(isInitAlready) return;
 
     // Initialize a new instance of the Analytics client.
     Analytics.Builder builder =
-        new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
+        new Analytics.Builder(context, ANALYTICS_WRITE_KEY)
             .trackApplicationLifecycleEvents()
             .trackAttributionInformation()
+            .logLevel(Analytics.LogLevel.VERBOSE)
             .recordScreenViews();
 
     // Set the initialized instance as a globally accessible instance.
     Analytics.setSingletonInstance(builder.build());
 
     // Now anytime you call Analytics.with, the custom instance will be returned.
-    Analytics analytics = Analytics.with(this);
+    Analytics analytics = Analytics.with(context);
 
     // If you need to know when integrations have been initialized, use the onIntegrationReady
     // listener.
@@ -66,5 +73,6 @@ public class SampleApp extends Application {
             Log.d("Segment Sample", "Segment integration ready.");
           }
         });
+    isInitAlready = true;
   }
 }

--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SecondActivity.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SecondActivity.java
@@ -1,0 +1,13 @@
+package com.segment.analytics.sample;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public class SecondActivity extends Activity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_second);
+  }
+}

--- a/analytics-samples/analytics-sample/src/main/res/layout/activity_second.xml
+++ b/analytics-samples/analytics-sample/src/main/res/layout/activity_second.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             tools:context=".SecondActivity"
+    >
+
+  <TextView
+      android:id="@+id/textView2"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_gravity="center"
+      android:text="Hello"
+      />
+</FrameLayout>


### PR DESCRIPTION
This PR reproduces an issue with lifecycle detection when initializing the Segment SDK lazily (i.e. in an Activity instead of the Application object).

To summarize, the first `Application Opened` event is never triggered. After that, **every time** a new Activity is opened we see Segment sends an `Application Backgrounded` and an `Application Opened` event.

We opened a support ticket with more details: https://segment.zendesk.com/hc/requests/376494

DO NOT MERGE