### PR TITLE
Add type to device context

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -239,6 +239,7 @@ public class AnalyticsContext extends ValueMap {
     device.put(Device.DEVICE_MANUFACTURER_KEY, Build.MANUFACTURER);
     device.put(Device.DEVICE_MODEL_KEY, Build.MODEL);
     device.put(Device.DEVICE_NAME_KEY, Build.DEVICE);
+    device.put(Device.DEVICE_TYPE_KEY, "android");
     put(DEVICE_KEY, device);
   }
 
@@ -414,6 +415,7 @@ public class AnalyticsContext extends ValueMap {
     @Private static final String DEVICE_MANUFACTURER_KEY = "manufacturer";
     @Private static final String DEVICE_MODEL_KEY = "model";
     @Private static final String DEVICE_NAME_KEY = "name";
+    @Private static final String DEVICE_TYPE_KEY = "type";
     @Private static final String DEVICE_TOKEN_KEY = "token";
     @Private static final String DEVICE_ADVERTISING_ID_KEY = "advertisingId";
     @Private static final String DEVICE_AD_TRACKING_ENABLED_KEY = "adTrackingEnabled";

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsContextTest.java
@@ -82,7 +82,8 @@ public class AnalyticsContextTest {
         .containsEntry("id", "unknown")
         .containsEntry("manufacturer", "unknown")
         .containsEntry("model", "unknown")
-        .containsEntry("name", "unknown");
+        .containsEntry("name", "unknown")
+        .containsEntry("type", "android");
 
     assertThat(context.getValueMap("library")) //
         .containsEntry("name", "analytics-android")
@@ -109,7 +110,8 @@ public class AnalyticsContextTest {
         .containsEntry("id", traits.anonymousId())
         .containsEntry("manufacturer", "unknown")
         .containsEntry("model", "unknown")
-        .containsEntry("name", "unknown");
+        .containsEntry("name", "unknown")
+        .containsEntry("type", "android");
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**
This PR adds the type to the device context (Customer.io for example requires the device type to be set [alongside the device token] in order to recognize devices). [The Segment iOS SDK is already setting the type.](https://github.com/segmentio/analytics-ios/blob/ac07c5f368743792c43f9c404f3781efcfb114f7/Analytics/Classes/Internal/SEGSegmentIntegration.m#L170)

**How should this be manually tested?**
Check in Segment’s event debugger if new events contain the `type` key within their `context/device` dictionary.

**Any background context you want to provide?**
We are developing in React Native and are using Firebase Cloud Messaging (via [React Native Firebase](https://rnfirebase.io/)). We want to use Customer.io to send out push notifications, so we are working on a pull request for the Segment React Native SDK to add functionality which is required to make this happen. Before we can continue our work we need a way to set the device type in Android – hence this pull request.

**What are the relevant tickets?**
segmentio/analytics-react-native#38

**Questions:**
- Does the docs need an update?
  No.
- Are there any security concerns?
  No.
- Do we need to update engineering / success?
  No.
