### PR TITLE
Set build property to String

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -349,15 +349,15 @@ public class Analytics {
           "Application Installed",
           new Properties() //
               .putValue(VERSION_KEY, currentVersion)
-              .putValue(BUILD_KEY, currentBuild));
+              .putValue(BUILD_KEY, String.valueOf(currentBuild)));
     } else if (currentBuild != previousBuild) {
       track(
           "Application Updated",
           new Properties() //
               .putValue(VERSION_KEY, currentVersion)
-              .putValue(BUILD_KEY, currentBuild)
+              .putValue(BUILD_KEY, String.valueOf(currentBuild))
               .putValue("previous_" + VERSION_KEY, previousVersion)
-              .putValue("previous_" + BUILD_KEY, previousBuild));
+              .putValue("previous_" + BUILD_KEY, String.valueOf(previousBuild)));
     }
 
     // Update the recorded version.

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -131,7 +131,7 @@ class AnalyticsActivityLifecycleCallbacks implements Application.ActivityLifecyc
       if (firstLaunch.get()) {
         properties
             .putValue("version", packageInfo.versionName)
-            .putValue("build", packageInfo.versionCode);
+            .putValue("build", String.valueOf(packageInfo.versionCode));
       }
       properties.putValue("from_background", !firstLaunch.getAndSet(false));
       analytics.track("Application Opened", properties);

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -810,7 +810,7 @@ public class AnalyticsTest {
                         && //
                         payload.properties().getString("version").equals("1.0.0")
                         && //
-                        payload.properties().getInt("build", -1) == 100;
+                        payload.properties().getString("build").equals(String.valueOf(100));
                   }
                 }));
 
@@ -894,11 +894,11 @@ public class AnalyticsTest {
                         && //
                         payload.properties().getString("previous_version").equals("1.0.0")
                         && //
-                        payload.properties().getInt("previous_build", -1) == 100
+                        payload.properties().getString("previous_build").equals(String.valueOf(100))
                         && //
                         payload.properties().getString("version").equals("1.0.1")
                         && //
-                        payload.properties().getInt("build", -1) == 101;
+                        payload.properties().getString("build").equals(String.valueOf(101));
                   }
                 }));
   }
@@ -1301,7 +1301,7 @@ public class AnalyticsTest {
                   protected boolean matchesSafely(TrackPayload payload) {
                     return payload.event().equals("Application Opened")
                         && payload.properties().getString("version").equals("1.0.0")
-                        && payload.properties().getInt("build", -1) == 100
+                        && payload.properties().getString("build").equals(String.valueOf(100))
                         && !payload.properties().getBoolean("from_background", true);
                   }
                 }));


### PR DESCRIPTION
**What does this PR do?**
For Application Installed, updated and first opened the build is sent as a property. This is sent as an int, although it sent as String in the Context object. Pr to standardize how this is sent.

**Any background context you want to provide?**
Previous issue for the build sent as an int in the context object: https://github.com/segmentio/analytics-android/issues/481