### PR TITLE
Test coverage fix after previous merge to master

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ buildscript {
   }
 }
 
+apply plugin: 'com.vanniktech.android.junit.jacoco'
+
 allprojects {
   buildscript {
     repositories {

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.diffplug.gradle.spotless'
-apply plugin: 'com.vanniktech.android.junit.jacoco'
 
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion

--- a/gradle/android.gradle
+++ b/gradle/android.gradle
@@ -22,9 +22,6 @@ android {
     release {
       minifyEnabled false
     }
-    debug {
-      testCoverageEnabled true
-    }
   }
 
   compileOptions {


### PR DESCRIPTION
Follow up to #658.

There was an issue with running test coverage after the previous merge to master, this caused CI to fail and CI was only ran after the merge took place.

The first change is to apply the plugin on the root project, this is in the instructions for the Gradle JaCoCo plugin and is likely just a change due to the project previously using a very old version of the plugin.

Also, there was an issue with test coverage for the androidTest variant (UI tests - End-to-End tests). The issue here was that the plugin tries to generate a coverage report for 'androidTest' on the analytics module and then fails as the coverage data doesn't exist, as androidTests haven't been executed.

To fix the issue, testCoverageEnabled has been disabled, which means test coverage is produced for unit tests but not androidTests. There would have been issues with androidTest coverage anyway due to the fact that they are on the sample module and the main code is in a library module with the unit tests.

I can't check Circle CI directly, however, after making this change the command that is ran on Circle CI is working locally from a clean-state.