### PR TITLE
Add DefaultIntegrationSettings to Analytics.Builder

### DIFF
--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
@@ -58,8 +58,7 @@ public class SampleApp extends Application {
                                 "Adjust",
                                 new ValueMap()
                                     .putValue("appToken", "<>")
-                                    .putValue("trackAttributionData", true)))
-            )
+                                    .putValue("trackAttributionData", true))))
             .recordScreenViews();
 
     // Set the initialized instance as a globally accessible instance.

--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- *
+ * <p>
  * Copyright (c) 2014 Segment.io, Inc.
- *
+ * <p>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * <p>
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * <p>
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -26,6 +26,7 @@ package com.segment.analytics.sample;
 import android.app.Application;
 import android.util.Log;
 import com.segment.analytics.Analytics;
+import com.segment.analytics.ValueMap;
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig;
 
 public class SampleApp extends Application {
@@ -48,6 +49,17 @@ public class SampleApp extends Application {
         new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
             .trackApplicationLifecycleEvents()
             .trackAttributionInformation()
+            .defaultIntegrationSettings(
+                new ValueMap()
+                    .putValue(
+                        "integrations",
+                        new ValueMap()
+                            .putValue(
+                                "Adjust",
+                                new ValueMap()
+                                    .putValue("appToken", "<>")
+                                    .putValue("trackAttributionData", true)))
+            )
             .recordScreenViews();
 
     // Set the initialized instance as a globally accessible instance.

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -224,7 +224,8 @@ public class Analytics {
       final boolean trackDeepLinks,
       BooleanPreference optOut,
       Crypto crypto,
-      @NonNull List<Middleware> middlewares) {
+      @NonNull List<Middleware> middlewares,
+      @NonNull final ValueMap defaultIntegrationSettings) {
     this.application = application;
     this.networkExecutor = networkExecutor;
     this.stats = stats;
@@ -257,6 +258,7 @@ public class Analytics {
               // Backup mode - Enable just the Segment integration.
               // {
               //   integrations: {
+              //     ...defaultIntegrationSettings
               //     Segment.io: {
               //       apiKey: "{writeKey}"
               //     }
@@ -267,7 +269,7 @@ public class Analytics {
                       new ValueMap() //
                           .putValue(
                               "integrations",
-                              new ValueMap()
+                              new ValueMap(defaultIntegrationSettings)
                                   .putValue(
                                       "Segment.io",
                                       new ValueMap().putValue("apiKey", Analytics.this.writeKey))));
@@ -1047,6 +1049,7 @@ public class Analytics {
     private boolean trackAttributionInformation = false;
     private boolean trackDeepLinks = false;
     private Crypto crypto;
+    private ValueMap defaultIntegrationSettings = new ValueMap();
 
     /** Start building a new {@link Analytics} instance. */
     public Builder(Context context, String writeKey) {
@@ -1254,6 +1257,15 @@ public class Analytics {
     }
 
     /**
+     * Add default integrations, in case of bad network connectivity
+     */
+    public Builder defaultIntegrationSettings(ValueMap defaultIntegrationSettings) {
+      assertNotNull(defaultIntegrationSettings, "defaultIntegrationSettings");
+      this.defaultIntegrationSettings = defaultIntegrationSettings;
+      return this;
+    }
+
+    /**
      * The executor on which payloads are dispatched asynchronously. This is not exposed publicly.
      */
     Builder executor(ExecutorService executor) {
@@ -1351,7 +1363,8 @@ public class Analytics {
           trackDeepLinks,
           optOut,
           crypto,
-          middlewares);
+          middlewares,
+          defaultIntegrationSettings);
     }
   }
 

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -1256,9 +1256,7 @@ public class Analytics {
       return this;
     }
 
-    /**
-     * Add default integrations, in case of bad network connectivity
-     */
+    /** Add default integrations, in case of bad network connectivity */
     public Builder defaultIntegrationSettings(ValueMap defaultIntegrationSettings) {
       assertNotNull(defaultIntegrationSettings, "defaultIntegrationSettings");
       this.defaultIntegrationSettings = defaultIntegrationSettings;


### PR DESCRIPTION
This change introduces a new `Analytics.Builder` option to include default integration settings in case of a lossy network (preventing fetching project settings from Segment)