### PR TITLE
Catch null intent data

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -93,7 +93,7 @@ class AnalyticsActivityLifecycleCallbacks implements Application.ActivityLifecyc
       }
 
       Intent intent = activity.getIntent();
-      if (activity.getIntent() == null) {
+      if (intent == null || intent.getData() == null) {
         return;
       }
 

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -1181,6 +1181,72 @@ public class AnalyticsTest {
   }
 
   @Test
+  public void trackDeepLinks_nullData() {
+    Analytics.INSTANCES.clear();
+
+    final AtomicReference<Application.ActivityLifecycleCallbacks> callback =
+            new AtomicReference<>();
+    doNothing()
+            .when(application)
+            .registerActivityLifecycleCallbacks(
+                    argThat(
+                            new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
+                              @Override
+                              protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                                callback.set(item);
+                                return true;
+                              }
+                            }));
+
+    analytics =
+            new Analytics(
+                    application,
+                    networkExecutor,
+                    stats,
+                    traitsCache,
+                    analyticsContext,
+                    defaultOptions,
+                    Logger.with(NONE),
+                    "qaz",
+                    Collections.singletonList(factory),
+                    client,
+                    Cartographer.INSTANCE,
+                    projectSettingsCache,
+                    "foo",
+                    DEFAULT_FLUSH_QUEUE_SIZE,
+                    DEFAULT_FLUSH_INTERVAL,
+                    analyticsExecutor,
+                    true,
+                    new CountDownLatch(0),
+                    false,
+                    false,
+                    false,
+                    optOut,
+                    Crypto.none(),
+                    Collections.<Middleware>emptyList(),
+                    new ValueMap());
+
+    Activity activity = mock(Activity.class);
+
+    Intent intent = mock(Intent.class);
+
+    when(activity.getIntent()).thenReturn(intent);
+    when(intent.getData()).thenReturn(null);
+
+    callback.get().onActivityCreated(activity, new Bundle());
+
+    verify(integration, never())
+            .track(
+                    argThat(
+                            new NoDescriptionMatcher<TrackPayload>() {
+                              @Override
+                              protected boolean matchesSafely(TrackPayload payload) {
+                                return payload.event().equals("Deep Link Opened");
+                              }
+                            }));
+  }
+
+  @Test
   public void registerActivityLifecycleCallbacks() throws NameNotFoundException {
     Analytics.INSTANCES.clear();
 

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -1185,46 +1185,46 @@ public class AnalyticsTest {
     Analytics.INSTANCES.clear();
 
     final AtomicReference<Application.ActivityLifecycleCallbacks> callback =
-            new AtomicReference<>();
+        new AtomicReference<>();
     doNothing()
-            .when(application)
-            .registerActivityLifecycleCallbacks(
-                    argThat(
-                            new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
-                              @Override
-                              protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
-                                callback.set(item);
-                                return true;
-                              }
-                            }));
+        .when(application)
+        .registerActivityLifecycleCallbacks(
+            argThat(
+                new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
+                  @Override
+                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
+                    callback.set(item);
+                    return true;
+                  }
+                }));
 
     analytics =
-            new Analytics(
-                    application,
-                    networkExecutor,
-                    stats,
-                    traitsCache,
-                    analyticsContext,
-                    defaultOptions,
-                    Logger.with(NONE),
-                    "qaz",
-                    Collections.singletonList(factory),
-                    client,
-                    Cartographer.INSTANCE,
-                    projectSettingsCache,
-                    "foo",
-                    DEFAULT_FLUSH_QUEUE_SIZE,
-                    DEFAULT_FLUSH_INTERVAL,
-                    analyticsExecutor,
-                    true,
-                    new CountDownLatch(0),
-                    false,
-                    false,
-                    false,
-                    optOut,
-                    Crypto.none(),
-                    Collections.<Middleware>emptyList(),
-                    new ValueMap());
+        new Analytics(
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(NONE),
+            "qaz",
+            Collections.singletonList(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL,
+            analyticsExecutor,
+            true,
+            new CountDownLatch(0),
+            false,
+            false,
+            false,
+            optOut,
+            Crypto.none(),
+            Collections.<Middleware>emptyList(),
+            new ValueMap());
 
     Activity activity = mock(Activity.class);
 
@@ -1236,14 +1236,14 @@ public class AnalyticsTest {
     callback.get().onActivityCreated(activity, new Bundle());
 
     verify(integration, never())
-            .track(
-                    argThat(
-                            new NoDescriptionMatcher<TrackPayload>() {
-                              @Override
-                              protected boolean matchesSafely(TrackPayload payload) {
-                                return payload.event().equals("Deep Link Opened");
-                              }
-                            }));
+        .track(
+            argThat(
+                new NoDescriptionMatcher<TrackPayload>() {
+                  @Override
+                  protected boolean matchesSafely(TrackPayload payload) {
+                    return payload.event().equals("Deep Link Opened");
+                  }
+                }));
   }
 
   @Test


### PR DESCRIPTION
**What does this PR do?**
When trackdeeplinks is enabled, this can result in a null pointer exception as getData() can return null while intent does not. 

**Any background context you want to provide?**
Fix for following issue: https://github.com/segmentio/analytics-android/issues/657