### PR TITLE
Prevent Global Context modification for one-time op

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Options.java
+++ b/analytics/src/main/java/com/segment/analytics/Options.java
@@ -48,6 +48,11 @@ public class Options {
     context = new ConcurrentHashMap<>();
   }
 
+  public Options(Map<String, Object> integrations, Map<String, Object> context) {
+    this.integrations = integrations;
+    this.context = context;
+  }
+
   /**
    * Sets whether an action will be sent to the target integration.
    *


### PR DESCRIPTION
## Summary
This PR prevents the global `analyticsContext` object from being modified when a user specifies additional context key-value pairs via the `Options` property.

This PR does not modify the overriding behavior of `Options` for any of the following api's
- `track(String, Properties, Options)`
- `identify(String, Traits, Options)`
- `group(String, Traits, Options)`
- `screen(String, String, Properties, Options)`
- `alias(String, Options)`
it acknowledges the behavior, and thus we expose an easier way to get around it.
We now have a `analytics.getDefaultOptions()` api that provides u with a **copy** of the default options object used when initializing the global analytics. And here is a simple way of leveraging this new API
```java
Analytics.with(this)
        .track(
            "Button B Clicked",
            null,
            Analytics.with(this)
                .getDefaultOptions()
                .putContext("protocols", new ValueMap().putValue("event_version", 1)));
```

## Test Plan
- using the `Options` property does not modify the global context
- using the `Options` property, extended using `analytics.defaultOptions` does not modify the global context