### PR TITLE
Fix alias not overridden by cached value

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -738,6 +738,7 @@ public class Analytics {
     builder.integrations(finalOptions.integrations());
     String cachedUserId = contextCopy.traits().userId();
     if (!builder.isUserIdSet() && !isNullOrEmpty(cachedUserId)) {
+      // userId is not set, retrieve from cached traits and set for payload
       builder.userId(cachedUserId);
     }
     enqueue(builder.build());

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -736,9 +736,9 @@ public class Analytics {
     builder.context(contextCopy);
     builder.anonymousId(contextCopy.traits().anonymousId());
     builder.integrations(finalOptions.integrations());
-    String userId = contextCopy.traits().userId();
-    if (!isNullOrEmpty(userId)) {
-      builder.userId(userId);
+    String cachedUserId = contextCopy.traits().userId();
+    if (!builder.isUserIdSet() && !isNullOrEmpty(cachedUserId)) {
+      builder.userId(cachedUserId);
     }
     enqueue(builder.build());
   }

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -318,9 +318,7 @@ public abstract class BasePayload extends ValueMap {
       return self();
     }
 
-    /**
-     * Returns true if userId is not-null or non-empty, false otherwise
-     */
+    /** Returns true if userId is not-null or non-empty, false otherwise */
     public boolean isUserIdSet() {
       return !isNullOrEmpty(userId);
     }

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -318,6 +318,13 @@ public abstract class BasePayload extends ValueMap {
       return self();
     }
 
+    /**
+     * Returns true if userId is not-null or non-empty, false otherwise
+     */
+    public boolean isUserIdSet() {
+      return !isNullOrEmpty(userId);
+    }
+
     abstract P realBuild(
         @NonNull String messageId,
         @NonNull Date timestamp,

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -577,6 +577,18 @@ public class AnalyticsTest {
   }
 
   @Test
+  public void aliasWithCachedUserID() {
+    analytics.identify("prayansh", new Traits().putValue("bar", "qaz"), null); // refer identifyUpdatesCache
+    analytics.alias("foo");
+    ArgumentCaptor<AliasPayload> payloadArgumentCaptor =
+        ArgumentCaptor.forClass(AliasPayload.class);
+    verify(integration).alias(payloadArgumentCaptor.capture());
+    assertThat(payloadArgumentCaptor.getValue())
+        .containsEntry("previousId", "prayansh")
+        .containsEntry("userId", "foo");
+  }
+
+  @Test
   public void flush() {
     analytics.flush();
 

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -578,7 +578,8 @@ public class AnalyticsTest {
 
   @Test
   public void aliasWithCachedUserID() {
-    analytics.identify("prayansh", new Traits().putValue("bar", "qaz"), null); // refer identifyUpdatesCache
+    analytics.identify(
+        "prayansh", new Traits().putValue("bar", "qaz"), null); // refer identifyUpdatesCache
     analytics.alias("foo");
     ArgumentCaptor<AliasPayload> payloadArgumentCaptor =
         ArgumentCaptor.forClass(AliasPayload.class);


### PR DESCRIPTION
## Summary
This PR fixes how `alias` works, and ensures that cached `userId` does not override the alias `userId` when making the call.
Resolves #633 and Closes #639 

## Test Plan
- `alias` call when `userId` is cached via previous `identify` call