### PR TITLE
Use AndroidX lifecycle functions for App Fore/Backgrounded

### DIFF
--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -6,7 +6,6 @@ apply from: rootProject.file('gradle/android.gradle')
 dependencies {
   api rootProject.ext.deps.supportAnnotations
 
-//  implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
   implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
   implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
 

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -6,6 +6,10 @@ apply from: rootProject.file('gradle/android.gradle')
 dependencies {
   api rootProject.ext.deps.supportAnnotations
 
+//  implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+  implementation 'androidx.lifecycle:lifecycle-process:2.2.0'
+  implementation 'androidx.lifecycle:lifecycle-common-java8:2.2.0'
+
   testImplementation 'junit:junit:4.12'
   testImplementation('org.robolectric:robolectric:3.5') {
     exclude group: 'commons-logging', module: 'commons-logging'

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -49,10 +49,7 @@ import android.os.Message;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleObserver;
-import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ProcessLifecycleOwner;
-
 import com.segment.analytics.integrations.AliasPayload;
 import com.segment.analytics.integrations.BasePayload;
 import com.segment.analytics.integrations.GroupPayload;

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -47,7 +47,6 @@ class AnalyticsActivityLifecycleCallbacks implements Application.ActivityLifecyc
 
   private AtomicBoolean trackedApplicationLifecycleEvents;
   private AtomicInteger numberOfActivities;
-  private AtomicBoolean isChangingActivityConfigurations;
   private AtomicBoolean firstLaunch;
 
   private AnalyticsActivityLifecycleCallbacks(
@@ -60,7 +59,6 @@ class AnalyticsActivityLifecycleCallbacks implements Application.ActivityLifecyc
       PackageInfo packageInfo) {
     this.trackedApplicationLifecycleEvents = new AtomicBoolean(false);
     this.numberOfActivities = new AtomicInteger(1);
-    this.isChangingActivityConfigurations = new AtomicBoolean(false);
     this.firstLaunch = new AtomicBoolean(false);
     this.analytics = analytics;
     this.analyticsExecutor = analyticsExecutor;

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- * <p>
+ *
  * Copyright (c) 2014 Segment.io, Inc.
- * <p>
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * <p>
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * <p>
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -36,7 +36,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class AnalyticsActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks, DefaultLifecycleObserver {
+class AnalyticsActivityLifecycleCallbacks
+    implements Application.ActivityLifecycleCallbacks, DefaultLifecycleObserver {
   private Analytics analytics;
   private ExecutorService analyticsExecutor;
   private Boolean shouldTrackApplicationLifecycleEvents;
@@ -70,7 +71,7 @@ class AnalyticsActivityLifecycleCallbacks implements Application.ActivityLifecyc
   }
 
   public void onStop(@NonNull LifecycleOwner owner) {
-    //App in background
+    // App in background
     if (shouldTrackApplicationLifecycleEvents) {
       analytics.track("Application Backgrounded");
     }

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -57,13 +56,10 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
 import android.os.Bundle;
-
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.ProcessLifecycleOwner;
-
 import com.segment.analytics.TestUtils.NoDescriptionMatcher;
 import com.segment.analytics.integrations.AliasPayload;
 import com.segment.analytics.integrations.GroupPayload;

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -57,6 +57,13 @@ import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleOwner;
+
 import com.segment.analytics.TestUtils.NoDescriptionMatcher;
 import com.segment.analytics.integrations.AliasPayload;
 import com.segment.analytics.integrations.GroupPayload;
@@ -109,6 +116,7 @@ public class AnalyticsTest {
   @Mock Stats stats;
   @Mock ProjectSettings.Cache projectSettingsCache;
   @Mock Integration integration;
+  @Mock Lifecycle lifecycle;
   private Options defaultOptions;
   private Integration.Factory factory;
   private BooleanPreference optOut;
@@ -183,7 +191,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     // Used by singleton tests.
     grantPermission(RuntimeEnvironment.application, Manifest.permission.INTERNET);
@@ -774,19 +783,19 @@ public class AnalyticsTest {
   public void trackApplicationLifecycleEventsInstalled() throws NameNotFoundException {
     Analytics.INSTANCES.clear();
 
-    final AtomicReference<Application.ActivityLifecycleCallbacks> callback =
-        new AtomicReference<>();
+    final AtomicReference<DefaultLifecycleObserver> callback = new AtomicReference<>();
     doNothing()
-        .when(application)
-        .registerActivityLifecycleCallbacks(
+        .when(lifecycle)
+        .addObserver(
             argThat(
-                new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
+                new NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
-                    callback.set(item);
+                  protected boolean matchesSafely(LifecycleObserver item) {
+                    callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
                 }));
+    LifecycleOwner mockLifecycleOwner = mock(LifecycleOwner.class);
 
     analytics =
         new Analytics(
@@ -815,9 +824,10 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
-    callback.get().onActivityCreated(null, null);
+    callback.get().onCreate(mockLifecycleOwner);
 
     verify(integration)
         .track(
@@ -833,7 +843,7 @@ public class AnalyticsTest {
                   }
                 }));
 
-    callback.get().onActivityCreated(null, null);
+    callback.get().onCreate(mockLifecycleOwner);
     verify(integration, times(2)).onActivityCreated(null, null);
     verifyNoMoreInteractions(integration);
   }
@@ -860,19 +870,19 @@ public class AnalyticsTest {
     when(application.getPackageName()).thenReturn("com.foo");
     when(application.getPackageManager()).thenReturn(packageManager);
 
-    final AtomicReference<Application.ActivityLifecycleCallbacks> callback =
-        new AtomicReference<>();
+    final AtomicReference<DefaultLifecycleObserver> callback = new AtomicReference<>();
     doNothing()
-        .when(application)
-        .registerActivityLifecycleCallbacks(
+        .when(lifecycle)
+        .addObserver(
             argThat(
-                new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
+                new NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
-                    callback.set(item);
+                  protected boolean matchesSafely(LifecycleObserver item) {
+                    callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
                 }));
+    LifecycleOwner mockLifecycleOwner = mock(LifecycleOwner.class);
 
     analytics =
         new Analytics(
@@ -901,9 +911,10 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
-    callback.get().onActivityCreated(null, null);
+    callback.get().onCreate(mockLifecycleOwner);
 
     verify(integration)
         .track(
@@ -969,7 +980,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     Activity activity = mock(Activity.class);
     PackageManager packageManager = mock(PackageManager.class);
@@ -1039,7 +1051,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     final String expectedUrl = "app://track.com/open?utm_id=12345&gclid=abcd&nope=";
 
@@ -1111,7 +1124,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     final String expectedUrl = "app://track.com/open?utm_id=12345&gclid=abcd&nope=";
 
@@ -1183,7 +1197,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     Activity activity = mock(Activity.class);
 
@@ -1246,7 +1261,9 @@ public class AnalyticsTest {
             optOut,
             Crypto.none(),
             Collections.<Middleware>emptyList(),
-            new ValueMap());
+            Collections.<String, List<Middleware>>emptyMap(),
+            new ValueMap(),
+            lifecycle);
 
     Activity activity = mock(Activity.class);
 
@@ -1313,7 +1330,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     Activity activity = mock(Activity.class);
     Bundle bundle = new Bundle();
@@ -1346,19 +1364,19 @@ public class AnalyticsTest {
   public void trackApplicationLifecycleEventsApplicationOpened() throws NameNotFoundException {
     Analytics.INSTANCES.clear();
 
-    final AtomicReference<Application.ActivityLifecycleCallbacks> callback =
-        new AtomicReference<>();
+    final AtomicReference<DefaultLifecycleObserver> callback = new AtomicReference<>();
     doNothing()
-        .when(application)
-        .registerActivityLifecycleCallbacks(
+        .when(lifecycle)
+        .addObserver(
             argThat(
-                new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
+                new NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
-                    callback.set(item);
+                  protected boolean matchesSafely(LifecycleObserver item) {
+                    callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
                 }));
+    LifecycleOwner mockLifecycleOwner = mock(LifecycleOwner.class);
 
     analytics =
         new Analytics(
@@ -1387,10 +1405,11 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
-    callback.get().onActivityCreated(null, null);
-    callback.get().onActivityResumed(null);
+    callback.get().onCreate(mockLifecycleOwner);
+    callback.get().onResume(mockLifecycleOwner);
 
     verify(integration)
         .track(
@@ -1411,19 +1430,20 @@ public class AnalyticsTest {
       throws NameNotFoundException {
     Analytics.INSTANCES.clear();
 
-    final AtomicReference<Application.ActivityLifecycleCallbacks> callback =
-        new AtomicReference<>();
+    final AtomicReference<DefaultLifecycleObserver> callback = new AtomicReference<>();
     doNothing()
-        .when(application)
-        .registerActivityLifecycleCallbacks(
+        .when(lifecycle)
+        .addObserver(
             argThat(
-                new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
+                new NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
-                    callback.set(item);
+                  protected boolean matchesSafely(LifecycleObserver item) {
+                    callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
                 }));
+
+    LifecycleOwner mockLifecycleOwner = mock(LifecycleOwner.class);
 
     analytics =
         new Analytics(
@@ -1452,14 +1472,15 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     Activity backgroundedActivity = mock(Activity.class);
     when(backgroundedActivity.isChangingConfigurations()).thenReturn(false);
 
-    callback.get().onActivityCreated(null, null);
-    callback.get().onActivityResumed(null);
-    callback.get().onActivityStopped(backgroundedActivity);
+    callback.get().onCreate(mockLifecycleOwner);
+    callback.get().onResume(mockLifecycleOwner);
+    callback.get().onStop(mockLifecycleOwner);
 
     verify(integration)
         .track(
@@ -1477,19 +1498,19 @@ public class AnalyticsTest {
       throws NameNotFoundException {
     Analytics.INSTANCES.clear();
 
-    final AtomicReference<Application.ActivityLifecycleCallbacks> callback =
-        new AtomicReference<>();
+    final AtomicReference<DefaultLifecycleObserver> callback = new AtomicReference<>();
     doNothing()
-        .when(application)
-        .registerActivityLifecycleCallbacks(
+        .when(lifecycle)
+        .addObserver(
             argThat(
-                new NoDescriptionMatcher<Application.ActivityLifecycleCallbacks>() {
+                new NoDescriptionMatcher<LifecycleObserver>() {
                   @Override
-                  protected boolean matchesSafely(Application.ActivityLifecycleCallbacks item) {
-                    callback.set(item);
+                  protected boolean matchesSafely(LifecycleObserver item) {
+                    callback.set((DefaultLifecycleObserver) item);
                     return true;
                   }
                 }));
+    LifecycleOwner mockLifecycleOwner = mock(LifecycleOwner.class);
 
     analytics =
         new Analytics(
@@ -1518,15 +1539,13 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
-    Activity backgroundedActivity = mock(Activity.class);
-    when(backgroundedActivity.isChangingConfigurations()).thenReturn(false);
-
-    callback.get().onActivityCreated(null, null);
-    callback.get().onActivityResumed(null);
-    callback.get().onActivityStopped(backgroundedActivity);
-    callback.get().onActivityResumed(null);
+    callback.get().onCreate(mockLifecycleOwner);
+    callback.get().onResume(mockLifecycleOwner);
+    callback.get().onStop(mockLifecycleOwner);
+    callback.get().onResume(mockLifecycleOwner);
 
     verify(integration)
         .track(
@@ -1608,7 +1627,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            new ValueMap());
+            new ValueMap(),
+            lifecycle);
 
     assertThat(analytics.shutdown).isFalse();
     analytics.shutdown();
@@ -1690,7 +1710,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            defaultProjectSettings);
+            defaultProjectSettings,
+            lifecycle);
 
     assertThat(analytics.projectSettings).hasSize(2).containsKey("integrations");
     assertThat(analytics.projectSettings.integrations())
@@ -1735,7 +1756,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            defaultProjectSettings);
+            defaultProjectSettings,
+            lifecycle);
 
     assertThat(analytics.projectSettings).hasSize(2).containsKey("integrations");
     assertThat(analytics.projectSettings.integrations()).hasSize(1).containsKey("Segment.io");
@@ -1786,7 +1808,8 @@ public class AnalyticsTest {
             Crypto.none(),
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
-            defaultProjectSettings);
+            defaultProjectSettings,
+            lifecycle);
 
     assertThat(analytics.projectSettings).hasSize(2).containsKey("integrations");
     assertThat(analytics.projectSettings.integrations()).hasSize(1).containsKey("Segment.io");

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -844,8 +844,7 @@ public class AnalyticsTest {
                 }));
 
     callback.get().onCreate(mockLifecycleOwner);
-    verify(integration, times(2)).onActivityCreated(null, null);
-    verifyNoMoreInteractions(integration);
+    verifyNoMoreInteractions(integration); // Application Installed is not duplicated
   }
 
   @Test
@@ -1409,7 +1408,7 @@ public class AnalyticsTest {
             lifecycle);
 
     callback.get().onCreate(mockLifecycleOwner);
-    callback.get().onResume(mockLifecycleOwner);
+    callback.get().onStart(mockLifecycleOwner);
 
     verify(integration)
         .track(
@@ -1543,9 +1542,9 @@ public class AnalyticsTest {
             lifecycle);
 
     callback.get().onCreate(mockLifecycleOwner);
-    callback.get().onResume(mockLifecycleOwner);
+    callback.get().onStart(mockLifecycleOwner);
     callback.get().onStop(mockLifecycleOwner);
-    callback.get().onResume(mockLifecycleOwner);
+    callback.get().onStart(mockLifecycleOwner);
 
     verify(integration)
         .track(


### PR DESCRIPTION
## Summary
Use `androidx.lifecycle` methods to fire `Application Backgrounded | Application Foregrounded` track calls when `trackApplicationLifecycleEvents=true`.
This feature allows us to load Segment Analytics "lazily" via an Activity rather than via the Application and still hook into all the lifecycle methods. This is due to the fact that `AnalyticsActivityLifecycleCallbacks.onCreate` gets called even if Analytics is loaded after the `Application.onCreate`.
The Lifecycle methods are also the recommended method of determining if an application is foregrounded/backgrounded.

## Test Plan
- `Application Backgrounded | Application Foregrounded` are sent when app starts. (Segment initialized via Application)
- `Application Backgrounded | Application Foregrounded` are sent when app starts. (Segment initialized via Activity)
- `Application Installed` are sent when app starts. (Segment initialized via Application)
- `Application Installed` are sent when app starts. (Segment initialized via Activity)