### PR TITLE
Fix: Proguard/R8 configuration for createValueMap

### DIFF
--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -3,6 +3,12 @@ apply plugin: 'com.getkeepsafe.dexcount'
 
 apply from: rootProject.file('gradle/android.gradle')
 
+android {
+  defaultConfig {
+    consumerProguardFiles 'proguard-rules-lib.txt'
+  }
+}
+
 dependencies {
   api rootProject.ext.deps.supportAnnotations
 

--- a/analytics/proguard-rules-lib.txt
+++ b/analytics/proguard-rules-lib.txt
@@ -1,0 +1,3 @@
+-keepclassmembers class com.segment.analytics.** {
+  <init>(java.util.Map);
+}

--- a/analytics/proguard-rules-lib.txt
+++ b/analytics/proguard-rules-lib.txt
@@ -1,3 +1,3 @@
--keepclassmembers class com.segment.analytics.** {
+-keepclassmembers class com.segment.analytics.** extends com.segment.analytics.ValueMap {
   <init>(java.util.Map);
 }


### PR DESCRIPTION
# Description of the issue
The method `com.segment.analytics.ValueMap#createValueMap` uses reflection to create an instance of the given `Class<T>`. It expects a constructor receiving a `Map`.

Unfortunately, for some classes like `Address`, this constructor is not used anywhere else in the code so applications using Proguard or R8 to remove unused code will delete this constructor. The outcome is a runtime crash in the application.

Here's an example extracted from Firebase Crashlytics in our production application:
<img width="1238" alt="Screenshot 2020-06-08 at 14 17 51" src="https://user-images.githubusercontent.com/545251/84029582-eb867b80-a992-11ea-8d7e-c225278b7b9c.png">

# How to reproduce
We could not reproduce the exact same execution path of our crash, which goes through the AppboyIntegration library. But we can manually force the crash by invoking the `getValueMap` method:
```java
Traits traits = new Traits();
traits.put("address", new ValueMap());
traits.getValueMap("address", Traits.Address.class);
```
It can be easily reproduced in the sample module by using the snippet above and enabling R8 in the `analytics-samples/build.gradle` file:
```groovy
android {
  // ...
  buildTypes {
    debug {
      minifyEnabled true
    }
  }
}
```

# The proposed fix
We implemented a workaround adding a Proguard rule into our application to stop it from removing code from the Segment SDK. 

This PR aims to solve this issue for all consumers of the SDK by providing a `consumerProguardFiles`. The rule in this file keeps classes containing a constructor receiving a map. Proguard/R8 will keep the name of the class from obfuscation and the constructor from being removed.

I believe this is just enough to avoid similar crashes, but please double-check the solution.
Here's some more info about the setup:
- [A library module may include its own ProGuard configuration file](https://developer.android.com/studio/projects/android-library#Considerations)
- [keepclasseswithmembers](https://www.guardsquare.com/en/products/proguard/manual/usage)