### PR TITLE
handle RuntimeException when calling `getActivityInfo`

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -408,10 +408,11 @@ public class Analytics {
       ActivityInfo info =
           packageManager.getActivityInfo(activity.getComponentName(), PackageManager.GET_META_DATA);
       CharSequence activityLabel = info.loadLabel(packageManager);
-      //noinspection deprecation
-      screen(null, activityLabel.toString());
+      screen(activityLabel.toString());
     } catch (PackageManager.NameNotFoundException e) {
       throw new AssertionError("Activity Not Found: " + e.toString());
+    } catch (Exception e) {
+      logger.error(e, "Unable to track screen view for %s", activity.toString());
     }
   }
 


### PR DESCRIPTION
## Summary
There has been a case of 
```
Fatal Exception: java.lang.RuntimeException: Package manager has died
```
This is an Android API call, and doesnt seem like the cause is us misusing the API. Online forums' best guess is that it may be due to hardware/other software issue.

Since we do not control the API, best we can do is guard against the Exception from being thrown, and logging it internally rather than crashing the application.

## Test Plan
Hard to reproduce. Plus this is mostly a guard against the exception being thrown, so no test cases required.

Closes #615 