### PR TITLE
Experimental Nanosecond timestamps

### DIFF
--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
@@ -34,7 +34,7 @@ import io.github.inflationx.viewpump.ViewPump;
 public class SampleApp extends Application {
 
   // https://segment.com/segment-engineering/sources/android-test/settings/keys
-  private static final String ANALYTICS_WRITE_KEY = "5m6gbdgho6";
+  private static final String ANALYTICS_WRITE_KEY = "8lScBxzFnESRxYxeNZyniANYovjrHBtP";
 
   @Override
   public void onCreate() {
@@ -53,6 +53,8 @@ public class SampleApp extends Application {
     // Initialize a new instance of the Analytics client.
     Analytics.Builder builder =
         new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
+            .flushQueueSize(1)
+            //            .experimentalNanosecondTimestamps()
             .trackApplicationLifecycleEvents()
             .trackAttributionInformation()
             .defaultProjectSettings(

--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
@@ -34,7 +34,7 @@ import io.github.inflationx.viewpump.ViewPump;
 public class SampleApp extends Application {
 
   // https://segment.com/segment-engineering/sources/android-test/settings/keys
-  private static final String ANALYTICS_WRITE_KEY = "8lScBxzFnESRxYxeNZyniANYovjrHBtP";
+  private static final String ANALYTICS_WRITE_KEY = "5m6gbdgho6";
 
   @Override
   public void onCreate() {
@@ -53,8 +53,6 @@ public class SampleApp extends Application {
     // Initialize a new instance of the Analytics client.
     Analytics.Builder builder =
         new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
-            .flushQueueSize(1)
-            //            .experimentalNanosecondTimestamps()
             .trackApplicationLifecycleEvents()
             .trackAttributionInformation()
             .defaultProjectSettings(

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -152,6 +152,8 @@ public class Analytics {
   private Map<String, Integration<?>> integrations;
   volatile boolean shutdown;
 
+  @Private final boolean nanosecondTimestamps;
+
   /**
    * Return a reference to the global default {@link Analytics} instance.
    *
@@ -233,7 +235,8 @@ public class Analytics {
       @NonNull List<Middleware> sourceMiddleware,
       @NonNull Map<String, List<Middleware>> destinationMiddleware,
       @NonNull final ValueMap defaultProjectSettings,
-      @NonNull Lifecycle lifecycle) {
+      @NonNull Lifecycle lifecycle,
+      boolean nanosecondTimestamps) {
     this.application = application;
     this.networkExecutor = networkExecutor;
     this.stats = stats;
@@ -256,6 +259,7 @@ public class Analytics {
     this.sourceMiddleware = sourceMiddleware;
     this.destinationMiddleware = destinationMiddleware;
     this.lifecycle = lifecycle;
+    this.nanosecondTimestamps = nanosecondTimestamps;
 
     namespaceSharedPreferences();
 
@@ -743,6 +747,7 @@ public class Analytics {
     builder.context(contextCopy);
     builder.anonymousId(contextCopy.traits().anonymousId());
     builder.integrations(finalOptions.integrations());
+    builder.nanosecondTimestamps(nanosecondTimestamps);
     String cachedUserId = contextCopy.traits().userId();
     if (!builder.isUserIdSet() && !isNullOrEmpty(cachedUserId)) {
       // userId is not set, retrieve from cached traits and set for payload
@@ -1051,6 +1056,7 @@ public class Analytics {
     private boolean recordScreenViews = false;
     private boolean trackAttributionInformation = false;
     private boolean trackDeepLinks = false;
+    private boolean nanosecondTimestamps = false;
     private Crypto crypto;
     private ValueMap defaultProjectSettings = new ValueMap();
 
@@ -1295,6 +1301,15 @@ public class Analytics {
     }
 
     /**
+     * Enable the use of nanoseconds timestamps for all payloads. Timestamps will be formatted as
+     * yyyy-MM-ddThh:mm:ss.nnnnnnnnnZ Note: This is an experimental feature (and strictly opt-in)
+     */
+    public Builder experimentalNanosecondTimestamps() {
+      this.nanosecondTimestamps = true;
+      return this;
+    }
+
+    /**
      * Set the default project settings to use, if Segment.com cannot be reached. An example
      * configuration can be found here, using your write key: <a
      * href="https://cdn-settings.segment.com/v1/projects/YOUR_WRITE_KEY/settings">
@@ -1411,7 +1426,8 @@ public class Analytics {
           srcMiddleware,
           destMiddleware,
           defaultProjectSettings,
-          lifecycle);
+          lifecycle,
+          nanosecondTimestamps);
     }
   }
 

--- a/analytics/src/main/java/com/segment/analytics/integrations/AliasPayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/AliasPayload.java
@@ -43,8 +43,17 @@ public class AliasPayload extends BasePayload {
       @NonNull Map<String, Object> integrations,
       @Nullable String userId,
       @NonNull String anonymousId,
-      @NonNull String previousId) {
-    super(Type.alias, messageId, timestamp, context, integrations, userId, anonymousId);
+      @NonNull String previousId,
+      boolean nanosecondTimestamps) {
+    super(
+        Type.alias,
+        messageId,
+        timestamp,
+        context,
+        integrations,
+        userId,
+        anonymousId,
+        nanosecondTimestamps);
     put(PREVIOUS_ID_KEY, previousId);
   }
 
@@ -95,12 +104,20 @@ public class AliasPayload extends BasePayload {
         @NonNull Map<String, Object> context,
         @NonNull Map<String, Object> integrations,
         @Nullable String userId,
-        @NonNull String anonymousId) {
+        @NonNull String anonymousId,
+        boolean nanosecondTimestamps) {
       assertNotNullOrEmpty(userId, "userId");
       assertNotNullOrEmpty(previousId, "previousId");
 
       return new AliasPayload(
-          messageId, timestamp, context, integrations, userId, anonymousId, previousId);
+          messageId,
+          timestamp,
+          context,
+          integrations,
+          userId,
+          anonymousId,
+          previousId,
+          nanosecondTimestamps);
     }
 
     @Override

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -27,7 +27,8 @@ import static com.segment.analytics.internal.Utils.assertNotNull;
 import static com.segment.analytics.internal.Utils.assertNotNullOrEmpty;
 import static com.segment.analytics.internal.Utils.immutableCopyOf;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
-import static com.segment.analytics.internal.Utils.parseISO8601Date;
+import static com.segment.analytics.internal.Utils.parseISO8601DateWithNanos;
+import static com.segment.analytics.internal.Utils.toISO8601NanoFormattedString;
 import static com.segment.analytics.internal.Utils.toISO8601String;
 
 import androidx.annotation.CheckResult;
@@ -35,6 +36,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.segment.analytics.AnalyticsContext;
 import com.segment.analytics.ValueMap;
+import com.segment.analytics.internal.NanoDate;
 import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -65,11 +67,16 @@ public abstract class BasePayload extends ValueMap {
       @NonNull Map<String, Object> context,
       @NonNull Map<String, Object> integrations,
       @Nullable String userId,
-      @NonNull String anonymousId) {
+      @NonNull String anonymousId,
+      boolean nanosecondTimestamps) {
     put(CHANNEL_KEY, Channel.mobile);
     put(TYPE_KEY, type);
     put(MESSAGE_ID, messageId);
-    put(TIMESTAMP_KEY, toISO8601String(timestamp));
+    if (nanosecondTimestamps) {
+      put(TIMESTAMP_KEY, toISO8601NanoFormattedString(timestamp));
+    } else {
+      put(TIMESTAMP_KEY, toISO8601String(timestamp));
+    }
     put(CONTEXT_KEY, context);
     put(INTEGRATIONS_KEY, integrations);
     if (!isNullOrEmpty(userId)) {
@@ -124,7 +131,7 @@ public abstract class BasePayload extends ValueMap {
     if (isNullOrEmpty(timestamp)) {
       return null;
     }
-    return parseISO8601Date(timestamp);
+    return parseISO8601DateWithNanos(timestamp);
   }
 
   /**
@@ -183,6 +190,7 @@ public abstract class BasePayload extends ValueMap {
     private Map<String, Object> integrationsBuilder;
     private String userId;
     private String anonymousId;
+    private boolean nanosecondTimestamps = false;
 
     Builder() {
       // Empty constructor.
@@ -323,13 +331,19 @@ public abstract class BasePayload extends ValueMap {
       return !isNullOrEmpty(userId);
     }
 
+    public B nanosecondTimestamps(boolean enabled) {
+      this.nanosecondTimestamps = enabled;
+      return self();
+    }
+
     abstract P realBuild(
         @NonNull String messageId,
         @NonNull Date timestamp,
         @NonNull Map<String, Object> context,
         @NonNull Map<String, Object> integrations,
         @Nullable String userId,
-        @NonNull String anonymousId);
+        @NonNull String anonymousId,
+        boolean nanosecondTimestamps);
 
     abstract B self();
 
@@ -351,14 +365,15 @@ public abstract class BasePayload extends ValueMap {
       }
 
       if (timestamp == null) {
-        timestamp = new Date();
+        timestamp = new NanoDate(); // captures higher resolution timestamps
       }
 
       if (isNullOrEmpty(context)) {
         context = Collections.emptyMap();
       }
 
-      return realBuild(messageId, timestamp, context, integrations, userId, anonymousId);
+      return realBuild(
+          messageId, timestamp, context, integrations, userId, anonymousId, nanosecondTimestamps);
     }
   }
 }

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -197,6 +197,10 @@ public abstract class BasePayload extends ValueMap {
     }
 
     Builder(BasePayload payload) {
+      String tsStr = payload.getString(TIMESTAMP_KEY);
+      if (tsStr != null && tsStr.length() > 24) { // [yyyy-MM-ddThh:mm:ss.sssZ] format without nanos
+        nanosecondTimestamps = true;
+      }
       messageId = payload.messageId();
       timestamp = payload.timestamp();
       context = payload.context();

--- a/analytics/src/main/java/com/segment/analytics/integrations/GroupPayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/GroupPayload.java
@@ -50,8 +50,17 @@ public class GroupPayload extends BasePayload {
       @Nullable String userId,
       @NonNull String anonymousId,
       @NonNull String groupId,
-      @NonNull Map<String, Object> traits) {
-    super(Type.group, messageId, timestamp, context, integrations, userId, anonymousId);
+      @NonNull Map<String, Object> traits,
+      boolean nanosecondTimestamps) {
+    super(
+        Type.group,
+        messageId,
+        timestamp,
+        context,
+        integrations,
+        userId,
+        anonymousId,
+        nanosecondTimestamps);
     put(GROUP_ID_KEY, groupId);
     put(TRAITS_KEY, traits);
   }
@@ -120,7 +129,8 @@ public class GroupPayload extends BasePayload {
         @NonNull Map<String, Object> context,
         @NonNull Map<String, Object> integrations,
         @Nullable String userId,
-        @NonNull String anonymousId) {
+        @NonNull String anonymousId,
+        boolean nanosecondTimestamps) {
       assertNotNullOrEmpty(groupId, "groupId");
 
       Map<String, Object> traits = this.traits;
@@ -129,7 +139,15 @@ public class GroupPayload extends BasePayload {
       }
 
       return new GroupPayload(
-          messageId, timestamp, context, integrations, userId, anonymousId, groupId, traits);
+          messageId,
+          timestamp,
+          context,
+          integrations,
+          userId,
+          anonymousId,
+          groupId,
+          traits,
+          nanosecondTimestamps);
     }
 
     @Override

--- a/analytics/src/main/java/com/segment/analytics/integrations/IdentifyPayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/IdentifyPayload.java
@@ -46,8 +46,17 @@ public class IdentifyPayload extends BasePayload {
       @NonNull Map<String, Object> integrations,
       @Nullable String userId,
       @NonNull String anonymousId,
-      @NonNull Map<String, Object> traits) {
-    super(Type.identify, messageId, timestamp, context, integrations, userId, anonymousId);
+      @NonNull Map<String, Object> traits,
+      boolean nanosecondTimestamps) {
+    super(
+        Type.identify,
+        messageId,
+        timestamp,
+        context,
+        integrations,
+        userId,
+        anonymousId,
+        nanosecondTimestamps);
     put(TRAITS_KEY, traits);
   }
 
@@ -102,13 +111,21 @@ public class IdentifyPayload extends BasePayload {
         @NonNull Map<String, Object> context,
         @NonNull Map<String, Object> integrations,
         String userId,
-        @NonNull String anonymousId) {
+        @NonNull String anonymousId,
+        boolean nanosecondTimestamps) {
       if (isNullOrEmpty(userId) && isNullOrEmpty(traits)) {
         throw new NullPointerException("either userId or traits are required");
       }
 
       return new IdentifyPayload(
-          messageId, timestamp, context, integrations, userId, anonymousId, traits);
+          messageId,
+          timestamp,
+          context,
+          integrations,
+          userId,
+          anonymousId,
+          traits,
+          nanosecondTimestamps);
     }
 
     @Override

--- a/analytics/src/main/java/com/segment/analytics/integrations/ScreenPayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/ScreenPayload.java
@@ -51,8 +51,17 @@ public class ScreenPayload extends BasePayload {
       @NonNull String anonymousId,
       @Nullable String name,
       @Nullable String category,
-      @NonNull Map<String, Object> properties) {
-    super(Type.screen, messageId, timestamp, context, integrations, userId, anonymousId);
+      @NonNull Map<String, Object> properties,
+      boolean nanosecondTimestamps) {
+    super(
+        Type.screen,
+        messageId,
+        timestamp,
+        context,
+        integrations,
+        userId,
+        anonymousId,
+        nanosecondTimestamps);
     if (!isNullOrEmpty(name)) {
       put(NAME_KEY, name);
     }
@@ -147,7 +156,8 @@ public class ScreenPayload extends BasePayload {
         @NonNull Map<String, Object> context,
         @NonNull Map<String, Object> integrations,
         @Nullable String userId,
-        @NonNull String anonymousId) {
+        @NonNull String anonymousId,
+        boolean nanosecondTimestamps) {
       if (isNullOrEmpty(name) && isNullOrEmpty(category)) {
         throw new NullPointerException("either name or category is required");
       }
@@ -166,7 +176,8 @@ public class ScreenPayload extends BasePayload {
           anonymousId,
           name,
           category,
-          properties);
+          properties,
+          nanosecondTimestamps);
     }
 
     @Override

--- a/analytics/src/main/java/com/segment/analytics/integrations/TrackPayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/TrackPayload.java
@@ -50,8 +50,17 @@ public class TrackPayload extends BasePayload {
       @Nullable String userId,
       @NonNull String anonymousId,
       @NonNull String event,
-      @NonNull Map<String, Object> properties) {
-    super(Type.track, messageId, timestamp, context, integrations, userId, anonymousId);
+      @NonNull Map<String, Object> properties,
+      boolean nanosecondTimestamps) {
+    super(
+        Type.track,
+        messageId,
+        timestamp,
+        context,
+        integrations,
+        userId,
+        anonymousId,
+        nanosecondTimestamps);
     put(EVENT_KEY, event);
     put(PROPERTIES_KEY, properties);
   }
@@ -123,7 +132,8 @@ public class TrackPayload extends BasePayload {
         @NonNull Map<String, Object> context,
         @NonNull Map<String, Object> integrations,
         String userId,
-        @NonNull String anonymousId) {
+        @NonNull String anonymousId,
+        boolean nanosecondTimestamps) {
       assertNotNullOrEmpty(event, "event");
 
       Map<String, Object> properties = this.properties;
@@ -132,7 +142,15 @@ public class TrackPayload extends BasePayload {
       }
 
       return new TrackPayload(
-          messageId, timestamp, context, integrations, userId, anonymousId, event, properties);
+          messageId,
+          timestamp,
+          context,
+          integrations,
+          userId,
+          anonymousId,
+          event,
+          properties,
+          nanosecondTimestamps);
     }
 
     @Override

--- a/analytics/src/main/java/com/segment/analytics/internal/NanoDate.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/NanoDate.java
@@ -1,0 +1,102 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Segment.io, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.segment.analytics.internal;
+
+import java.util.Date;
+
+public class NanoDate extends Date {
+  /*
+   * Java Genetic Algorithm Library (@__identifier__@).
+   * Copyright (c) @__year__@ Franz Wilhelmstötter
+   *
+   * Licensed under the Apache License, Version 2.0 (the "License");
+   * you may not use this file except in compliance with the License.
+   * You may obtain a copy of the License at
+   *
+   *      http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   *
+   * Author:
+   *    Franz Wilhelmstötter (franz.wilhelmstoetter@gmail.com)
+   */
+  public static final class NanoClock {
+    /**
+     * Jenetics' NanoClock to get higher resolution timestamps, pruned to our needs. Forked from
+     * this file
+     * https://github.com/jenetics/jenetics/blob/master/jenetics/src/main/java/io/jenetics/util/NanoClock.java
+     */
+    private static final long EPOCH_NANOS = System.currentTimeMillis() * 1_000_000;
+
+    private static final long NANO_START = System.nanoTime();
+    private static final long OFFSET_NANOS = EPOCH_NANOS - NANO_START;
+
+    /**
+     * This returns the nanosecond-based instant, measured from 1970-01-01T00:00Z (UTC). This method
+     * will return valid values till the year 2262.
+     *
+     * @return the nanosecond-based instant, measured from 1970-01-01T00:00Z (UTC)
+     */
+    private long nanos() {
+      return System.nanoTime() + OFFSET_NANOS;
+    }
+
+    public static long currentTimeNanos() {
+      return new NanoClock().nanos();
+    }
+  }
+
+  private long nanos;
+
+  public NanoDate() {
+    this(NanoClock.currentTimeNanos());
+  }
+
+  public NanoDate(Date d) {
+    this(d.getTime() * 1_000_000);
+  }
+
+  public NanoDate(long nanos) {
+    super(nanos / 1_000_000);
+    this.nanos = nanos;
+  }
+
+  public long nanos() {
+    return nanos;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof NanoDate) {
+      return ((NanoDate) obj).nanos() == nanos();
+    } else if (obj instanceof Date) {
+      return super.equals(obj) && nanos % 1_000_000 == 0;
+    }
+    return false;
+  }
+}

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -98,6 +98,11 @@ public final class Utils {
     return Iso8601Utils.format(date);
   }
 
+  /** Returns {@code date} formatted as yyyy-MM-ddThh:mm:ss.fffffffffZ */
+  public static String toISO8601NanoFormattedString(Date date) {
+    return Iso8601Utils.formatNanos(date);
+  }
+
   /**
    * Parse a date from ISO-8601 formatted string. It expects a format
    * [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh:mm]]
@@ -112,6 +117,17 @@ public final class Utils {
   /** @deprecated Use {@link #parseISO8601Date(String)}. */
   public static Date toISO8601Date(String date) throws ParseException {
     return parseISO8601Date(date);
+  }
+
+  /**
+   * Parse a date from ISO-8601 formatted string. It expects a format
+   * [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.fffffffff]]|hhmm[ss[.fffffffff]])]?[Z|[+-]hh:mm]]
+   *
+   * @param date ISO string to parse in the appropriate format.
+   * @return the parsed date
+   */
+  public static NanoDate parseISO8601DateWithNanos(String date) {
+    return Iso8601Utils.parseWithNanos(date);
   }
 
   // TODO: Migrate other coercion methods.

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.java
@@ -189,7 +189,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     // Used by singleton tests.
     grantPermission(RuntimeEnvironment.application, Manifest.permission.INTERNET);
@@ -822,7 +823,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     callback.get().onCreate(mockLifecycleOwner);
 
@@ -908,7 +910,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     callback.get().onCreate(mockLifecycleOwner);
 
@@ -977,7 +980,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     Activity activity = mock(Activity.class);
     PackageManager packageManager = mock(PackageManager.class);
@@ -1048,7 +1052,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     final String expectedUrl = "app://track.com/open?utm_id=12345&gclid=abcd&nope=";
 
@@ -1121,7 +1126,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     final String expectedUrl = "app://track.com/open?utm_id=12345&gclid=abcd&nope=";
 
@@ -1194,7 +1200,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     Activity activity = mock(Activity.class);
 
@@ -1259,7 +1266,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     Activity activity = mock(Activity.class);
 
@@ -1327,7 +1335,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     Activity activity = mock(Activity.class);
     Bundle bundle = new Bundle();
@@ -1402,7 +1411,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     callback.get().onCreate(mockLifecycleOwner);
     callback.get().onStart(mockLifecycleOwner);
@@ -1469,7 +1479,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     Activity backgroundedActivity = mock(Activity.class);
     when(backgroundedActivity.isChangingConfigurations()).thenReturn(false);
@@ -1536,7 +1547,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     callback.get().onCreate(mockLifecycleOwner);
     callback.get().onStart(mockLifecycleOwner);
@@ -1624,7 +1636,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     assertThat(analytics.shutdown).isFalse();
     analytics.shutdown();
@@ -1719,7 +1732,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             new ValueMap(),
-            lifecycle);
+            lifecycle,
+            false);
 
     assertThat(analytics.shutdown).isFalse();
     analytics.shutdown();
@@ -1789,7 +1803,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             defaultProjectSettings,
-            lifecycle);
+            lifecycle,
+            false);
 
     assertThat(analytics.projectSettings).hasSize(2).containsKey("integrations");
     assertThat(analytics.projectSettings.integrations())
@@ -1835,7 +1850,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             defaultProjectSettings,
-            lifecycle);
+            lifecycle,
+            false);
 
     assertThat(analytics.projectSettings).hasSize(2).containsKey("integrations");
     assertThat(analytics.projectSettings.integrations()).hasSize(1).containsKey("Segment.io");
@@ -1887,7 +1903,8 @@ public class AnalyticsTest {
             Collections.<Middleware>emptyList(),
             Collections.<String, List<Middleware>>emptyMap(),
             defaultProjectSettings,
-            lifecycle);
+            lifecycle,
+            false);
 
     assertThat(analytics.projectSettings).hasSize(2).containsKey("integrations");
     assertThat(analytics.projectSettings.integrations()).hasSize(1).containsKey("Segment.io");
@@ -1916,5 +1933,87 @@ public class AnalyticsTest {
     assertThat(payload.getValue().context()).containsKey("testProp");
     assertThat(payload.getValue().context().get("testProp")).isEqualTo(true);
     assertThat(analytics.analyticsContext).doesNotContainKey("testProp");
+  }
+
+  @Test
+  public void enableExperimentalNanosecondResolutionTimestamps() {
+    Analytics.INSTANCES.clear();
+    analytics =
+        new Analytics(
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(NONE),
+            "qaz",
+            Collections.singletonList(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL,
+            analyticsExecutor,
+            true,
+            new CountDownLatch(0),
+            false,
+            false,
+            false,
+            optOut,
+            Crypto.none(),
+            Collections.<Middleware>emptyList(),
+            Collections.<String, List<Middleware>>emptyMap(),
+            new ValueMap(),
+            lifecycle,
+            true);
+
+    analytics.track("event");
+    ArgumentCaptor<TrackPayload> payload = ArgumentCaptor.forClass(TrackPayload.class);
+    verify(integration).track(payload.capture());
+    String timestamp = (String) payload.getValue().get("timestamp");
+    assertThat(timestamp).matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{9}Z");
+  }
+
+  @Test
+  public void disableExperimentalNanosecondResolutionTimestamps() {
+    Analytics.INSTANCES.clear();
+    analytics =
+        new Analytics(
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(NONE),
+            "qaz",
+            Collections.singletonList(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL,
+            analyticsExecutor,
+            true,
+            new CountDownLatch(0),
+            false,
+            false,
+            false,
+            optOut,
+            Crypto.none(),
+            Collections.<Middleware>emptyList(),
+            Collections.<String, List<Middleware>>emptyMap(),
+            new ValueMap(),
+            lifecycle,
+            false);
+
+    analytics.track("event");
+    ArgumentCaptor<TrackPayload> payload = ArgumentCaptor.forClass(TrackPayload.class);
+    verify(integration).track(payload.capture());
+    String timestamp = (String) payload.getValue().get("timestamp");
+    assertThat(timestamp).matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z");
   }
 }

--- a/analytics/src/test/java/com/segment/analytics/internal/Iso8601UtilsTest.java
+++ b/analytics/src/test/java/com/segment/analytics/internal/Iso8601UtilsTest.java
@@ -40,6 +40,7 @@ public class Iso8601UtilsTest {
   private Date dateWithoutTime;
   private Date dateZeroMillis;
   private Date dateZeroSecondAndMillis;
+  private Date dateWithNano;
 
   @Before
   public void setUp() {
@@ -56,6 +57,7 @@ public class Iso8601UtilsTest {
     cal.set(Calendar.MILLISECOND, 0);
     cal.setTimeZone(TimeZone.getTimeZone("GMT"));
     dateWithoutTime = cal.getTime();
+    dateWithNano = new NanoDate(1187207505345554387L);
   }
 
   @Test
@@ -64,6 +66,19 @@ public class Iso8601UtilsTest {
     assertThat(Iso8601Utils.format(dateWithoutTime)).isEqualTo("2007-08-13T00:00:00.000Z");
     assertThat(Iso8601Utils.format(dateZeroMillis)).isEqualTo("2007-08-13T19:51:23.000Z");
     assertThat(Iso8601Utils.format(dateZeroSecondAndMillis)).isEqualTo("2007-08-13T19:51:00.000Z");
+    assertThat(Iso8601Utils.format(dateWithNano)).isEqualTo("2007-08-15T19:51:45.345Z");
+  }
+
+  @Test
+  public void formatNanos() {
+    assertThat(Iso8601Utils.formatNanos(date)).isEqualTo("2007-08-13T19:51:23.789000000Z");
+    assertThat(Iso8601Utils.formatNanos(dateWithoutTime))
+        .isEqualTo("2007-08-13T00:00:00.000000000Z");
+    assertThat(Iso8601Utils.formatNanos(dateZeroMillis))
+        .isEqualTo("2007-08-13T19:51:23.000000000Z");
+    assertThat(Iso8601Utils.formatNanos(dateZeroSecondAndMillis))
+        .isEqualTo("2007-08-13T19:51:00.000000000Z");
+    assertThat(Iso8601Utils.formatNanos(dateWithNano)).isEqualTo("2007-08-15T19:51:45.345554387Z");
   }
 
   @Test
@@ -71,6 +86,24 @@ public class Iso8601UtilsTest {
     assertThat(Iso8601Utils.parse("2007-08-13T19:51:23.789Z")).isEqualTo(date);
     assertThat(Iso8601Utils.parse("2007-08-13T19:51:23Z")).isEqualTo(dateZeroMillis);
     assertThat(Iso8601Utils.parse("2007-08-13T21:51:23.789+02:00")).isEqualTo(date);
+  }
+
+  @Test
+  public void parseWithNanos() {
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-13T19:51:23.789Z")).isEqualTo(date);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-13T19:51:23.789000000Z")).isEqualTo(date);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-13T19:51:23Z")).isEqualTo(dateZeroMillis);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-13T19:51:23.000000000Z"))
+        .isEqualTo(dateZeroMillis);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-13T21:51:23.789+02:00")).isEqualTo(date);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-13T21:51:23.789000000+02:00")).isEqualTo(date);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-15T19:51:45.345554387Z"))
+        .isEqualTo(dateWithNano);
+    assertThat(Iso8601Utils.parseWithNanos("20070815T19:51:45.345554387Z")).isEqualTo(dateWithNano);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-15T195145.345554387Z")).isEqualTo(dateWithNano);
+    assertThat(Iso8601Utils.parseWithNanos("20070815T195145.345554387Z")).isEqualTo(dateWithNano);
+    assertThat(Iso8601Utils.parseWithNanos("2007-08-15T21:51:45.345554387+02:00"))
+        .isEqualTo(dateWithNano);
   }
 
   @Test


### PR DESCRIPTION
## Summary
New Builder option to enable collection of Nanosecond resolution timestamps with this format `yyyy-MM-ddThh:mm:ss.fffffffffZ`.

### To enable
```java
Analytics.Builder builder =
        new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
            .experimentalNanosecondTimestamps()
```

Currently `java.util.Date` does not support resolution beyond milliseconds and `java.time.*` functions are not available for `<= API 21`. We could potentially have used [API Desugaring](https://developer.android.com/studio/releases/gradle-plugin#j8-library-desugaring), but this requires us to enable multidexing, which might not be favorable + could break current lower level API support. 
Considering all of this, I chose to implement a layer over `java.util.Date` which can hold higher resolution timestamps. 
**Note: the actual resolved value depends on device hardware**. 
We use `System.nanoTime()` to retrieve higher resolution times, but this does not measure time since epoch, but rather time since some fixed but arbitrary origin time. I referred to this [implementation](https://github.com/jenetics/jenetics/blob/master/jenetics/src/main/java/io/jenetics/util/NanoClock.java) for measuring this value.

The implementation should be a drop in replacement for the original implementation and wont break any existing implementations. Users can also leverage the new `NanoDate` and `NanoClock` classes in their own code. 

**Note: We should move to using `java.time.*` package, especially `java.time.Instant` as soon as possible. Most likely as part of the next major version release**

### The math behind it (if u r interested)
Let `T1` be time measured since Epoch (`E`), and `T2` be time measured at the same instant (approximately) since a random but arbitrary origin time (`O`).
Now to measure the time since epoch at any given time `T3` since `O` is as easy as: 
```
(T3 - O) + [(T1 - E) - (T2 - O)])
=> T3 - O + T1 - E - T2 + O
=> T3 + T1 - T2 - E
=> (T3 + T1 - T2) - E
=> T3 - E (Since T1 and T2 were measured approximately at the same instant)
```

## Test Plan
- Tests for converting from/to the new format.
- Tests for verifying if correct format is used in output payloads