### PR TITLE
Make new Lifecycle flow opt-out

### DIFF
--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
@@ -37,7 +37,7 @@ import io.github.inflationx.viewpump.ViewPump;
 public class SampleApp extends Application {
 
   // https://segment.com/segment-engineering/sources/android-test/settings/keys
-  private static final String ANALYTICS_WRITE_KEY = "HO63Z36e0Ufa8AAgbjDomDuKxFuUICqI";
+  private static final String ANALYTICS_WRITE_KEY = "5m6gbdgho6";
 
   @Override
   public void onCreate() {

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -1321,7 +1321,8 @@ public class Analytics {
       return this;
     }
 
-    public Builder useNewLifecycleMethods(boolean useNewLifecycleMethods) {
+    /** Enable/Disable the use of the new Lifecycle Observer methods. Enabled by default. */
+    public Builder experimentalUseNewLifecycleMethods(boolean useNewLifecycleMethods) {
       this.useNewLifecycleMethods = useNewLifecycleMethods;
       return this;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.segment.analytics.android
 
-VERSION_CODE=440
-VERSION_NAME=4.8.0
+VERSION_CODE=481
+VERSION_NAME=4.8.2-SNAPSHOT
 
 POM_NAME=Segment for Android
 POM_DESCRIPTION=The hassle-free way to add analytics to your Android app.


### PR DESCRIPTION
This is a potential fix for issue currently faced by some android tv users.
This change doesnt completely remove the new lifecycle process, but rather allows switching between the new and legacy flow.
A new builder option useNewLifecycleMethods is introduced which defaults to true, and to opt-out of the new flow use
```java
Analytics.Builder builder =
        new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
            ...
            .experimentalUseNewLifecycleMethods(false)
```

Implementation:
This code path controls the use of the new lifecycle flow: https://github.com/segmentio/analytics-android/pull/681/files#diff-a18a86eda368939313a371b220e906f0R331
If we circumvent ^ registration, then the onStart, onCreate, onStop functions in AnalyticsActivityLifecycleCallbacks wont get implicitly called, so we add these changes
https://github.com/segmentio/analytics-android/pull/681/files#diff-12bb80c3903ca5bd6c71fc44ea4ad80bR211
https://github.com/segmentio/analytics-android/pull/681/files#diff-12bb80c3903ca5bd6c71fc44ea4ad80bR197
https://github.com/segmentio/analytics-android/pull/681/files#diff-12bb80c3903ca5bd6c71fc44ea4ad80bR158
that will call the functions via the legacy lifecycle flow