### PR TITLE
updated formatting of  @Test and @Throws annotations in tests

### DIFF
--- a/analytics/src/test/java/com/segment/analytics/BatchPayloadWriterTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/BatchPayloadWriterTest.kt
@@ -13,6 +13,7 @@ import java.io.IOException
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class BatchPayloadWriterTest {
+
   @Test
   @Throws(IOException::class)
   fun batchPayloadWriter() {
@@ -33,8 +34,8 @@ class BatchPayloadWriterTest {
         .contains("{\"batch\":[foobarbazqux,{},2],\"sentAt\":\"")
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun batchPayloadWriterSingleItem() {
     val byteArrayOutputStream = ByteArrayOutputStream()
     val batchPayloadWriter = BatchPayloadWriter(byteArrayOutputStream)
@@ -51,8 +52,8 @@ class BatchPayloadWriterTest {
         .contains("{\"batch\":[qaz],\"sentAt\":\"")
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun batchPayloadWriterFailsForNoItem() {
     val byteArrayOutputStream = ByteArrayOutputStream()
     val batchPayloadWriter = BatchPayloadWriter(byteArrayOutputStream)

--- a/analytics/src/test/java/com/segment/analytics/CryptoTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/CryptoTest.kt
@@ -14,8 +14,8 @@ import java.io.IOException
 @Config(manifest = Config.NONE)
 class CryptoTest {
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun noneCryptoWrite() {
     val crypto: Crypto = Crypto.none()
     val foo: ByteString = ByteString.encodeUtf8("foo")

--- a/analytics/src/test/java/com/segment/analytics/IntegrationOperationTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/IntegrationOperationTest.kt
@@ -78,8 +78,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun trackPlanForEvent() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -99,8 +99,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun trackWithOptionsAndWithoutEventPlan() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed")
@@ -123,8 +123,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration, Mockito.never()).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun trackPlanForEventWithOptions() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed")
@@ -147,8 +147,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration, Mockito.never()).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun trackPlanDisabledEvent() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -170,8 +170,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration, Mockito.never()).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun trackPlanDisabledEventSendsToSegment() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -193,8 +193,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun trackPlanDisabledIntegration() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -218,8 +218,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration, Mockito.never()).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun trackPlanEnabledIntegration() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -242,8 +242,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun ignoresSegment() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -267,8 +267,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun defaultNewEventsEnabled() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -291,8 +291,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun defaultNewEventsDisabled() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -314,8 +314,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration, Mockito.never()).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun defaultNewEventsDisabledSendToSegment() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()
@@ -337,8 +337,8 @@ class IntegrationOperationTest {
     Mockito.verify(integration).track(payload)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun eventPlanOverridesSchemaDefualt() {
     val payload = TrackPayload.Builder()
         .event("Install Attributed").userId("userId").build()

--- a/analytics/src/test/java/com/segment/analytics/LoggerTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/LoggerTest.kt
@@ -14,6 +14,7 @@
   @RunWith(RobolectricTestRunner::class)
   @Config(manifest = Config.NONE)
   class LoggerTest {
+
     @Test
     fun verboseLevelLogsEverything() {
       val logger = Logger.with(Analytics.LogLevel.VERBOSE)

--- a/analytics/src/test/java/com/segment/analytics/OptionsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/OptionsTest.kt
@@ -11,14 +11,13 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class OptionsTest {
-
   private lateinit var options: Options
 
   @Before
   fun setUp() { options = Options() }
 
-  @Throws(Exception::class)
   @Test
+  @Throws(Exception::class)
   fun disallowsDisablingSegmentIntegration() {
     try{
       options.setIntegration("Segment.io", true)
@@ -29,8 +28,8 @@ class OptionsTest {
     }
   }
 
-  @Throws(Exception::class)
   @Test
+  @Throws(Exception::class)
   fun setIntegration() {
     options.setIntegration("Mixpanel", true)
     options.setIntegration("All", false)

--- a/analytics/src/test/java/com/segment/analytics/StatsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/StatsTest.kt
@@ -13,7 +13,6 @@ import java.io.IOException
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class StatsTest {
-
   private lateinit var stats: Stats
 
   @Before
@@ -21,8 +20,8 @@ class StatsTest {
     stats = Stats()
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun performFlush() {
     stats.performFlush(4)
     Assertions.assertThat(stats.flushCount).isEqualTo(1)
@@ -33,8 +32,8 @@ class StatsTest {
     Assertions.assertThat(stats.flushEventCount).isEqualTo(14)
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun performIntegrationOperation() {
     stats.performIntegrationOperation(Pair("foo", 43L))
     Assertions.assertThat(stats.integrationOperationCount).isEqualTo(1)
@@ -57,8 +56,8 @@ class StatsTest {
         .contains(MapEntry.entry("bar", 21L))
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun createSnapshot() {
     stats.performFlush(1)
     stats.performFlush(1)
@@ -99,8 +98,8 @@ class StatsTest {
     }
   }
 
-  @Throws(IOException::class)
   @Test
+  @Throws(IOException::class)
   fun createEmptySnapshot() {
     val snapshot: StatsSnapshot = stats.createSnapshot()
 


### PR DESCRIPTION
updated formatting of  @Test and @Throws annotations in several Kotlin tests to be in the correct order