### PR TITLE
Enable jacoco test coverage to run for robolectric tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ analytics-android
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.segment.analytics.android/analytics/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.segment.analytics.android/analytics)
 [![Javadocs](http://javadoc-badge.appspot.com/com.segment.analytics.android/analytics.svg?label=javadoc)](http://javadoc-badge.appspot.com/com.segment.analytics.android/analytics)
+[![CircleCI](https://circleci.com/gh/segmentio/analytics-android.svg?style=svg)](https://circleci.com/gh/segmentio/analytics-android)
+[![codecov](https://codecov.io/gh/segmentio/analytics-android/branch/master/graph/badge.svg)](https://codecov.io/gh/segmentio/analytics-android)
 
 analytics-android is an Android client for [Segment](https://segment.com)
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,10 @@ buildscript {
 
 apply plugin: 'com.vanniktech.android.junit.jacoco'
 
+junitJacoco {
+  includeNoLocationClasses = true // Used to generate coverage for robolectric tests
+}
+
 allprojects {
   buildscript {
     repositories {


### PR DESCRIPTION
Leverage this change https://github.com/vanniktech/gradle-android-junit-jacoco-plugin/pull/55 to allow running robolectric tests under jacoco coverage.

Also add badges to highlight on the front page