### PR TITLE
Enable faster project settings refresh when debugging enabled

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -49,7 +49,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
-import com.segment.analytics.core.BuildConfig;
+
 import com.segment.analytics.integrations.AliasPayload;
 import com.segment.analytics.integrations.BasePayload;
 import com.segment.analytics.integrations.GroupPayload;
@@ -1548,7 +1548,7 @@ public class Analytics {
     }
 
     private long getSettingsRefreshInterval() {
-        if (BuildConfig.DEBUG) {
+        if (logger.logLevel == LogLevel.DEBUG) {
             return 60 * 1000; // 1 minute
         }
         return SETTINGS_REFRESH_INTERVAL;

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -1547,10 +1547,11 @@ public class Analytics {
     }
 
     private long getSettingsRefreshInterval() {
+        long returnInterval = SETTINGS_REFRESH_INTERVAL;
         if (logger.logLevel == LogLevel.DEBUG) {
-            return 60 * 1000; // 1 minute
+            returnInterval = 60 * 1000; // 1 minute
         }
-        return SETTINGS_REFRESH_INTERVAL;
+        return returnInterval;
     }
 
     void performInitializeIntegrations(ProjectSettings projectSettings) throws AssertionError {

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -49,6 +49,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
+import com.segment.analytics.core.BuildConfig;
 import com.segment.analytics.integrations.AliasPayload;
 import com.segment.analytics.integrations.BasePayload;
 import com.segment.analytics.integrations.GroupPayload;
@@ -1534,7 +1535,7 @@ public class Analytics {
             return downloadSettings();
         }
 
-        long expirationTime = cachedSettings.timestamp() + SETTINGS_REFRESH_INTERVAL;
+        long expirationTime = cachedSettings.timestamp() + getSettingsRefreshInterval();
         if (expirationTime > System.currentTimeMillis()) {
             return cachedSettings;
         }
@@ -1544,6 +1545,13 @@ public class Analytics {
             return cachedSettings;
         }
         return downloadedSettings;
+    }
+
+    private long getSettingsRefreshInterval() {
+        if (BuildConfig.DEBUG) {
+            return 60 * 1000; // 1 minute
+        }
+        return SETTINGS_REFRESH_INTERVAL;
     }
 
     void performInitializeIntegrations(ProjectSettings projectSettings) throws AssertionError {

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -49,7 +49,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.ProcessLifecycleOwner;
-
 import com.segment.analytics.integrations.AliasPayload;
 import com.segment.analytics.integrations.BasePayload;
 import com.segment.analytics.integrations.GroupPayload;


### PR DESCRIPTION
In order to refresh settings faster when debugging, we now change the mobile cache ttl to 1 minute when in debug mode.