### PR TITLE
additional identify tests for LIBMOBILE-49

### DIFF
--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -265,6 +265,23 @@ open class AnalyticsTest {
     }
 
     @Test
+    fun identifyNullTraits() {
+        analytics.identify("userId", null, null)
+
+        assertThat(traits.userId()).isEqualTo("userId")
+        assertThat(traits.username()).isNull()
+    }
+
+    @Test
+    fun identifySavesPreviousTraits() {
+        analytics.identify("userId", Traits().putUsername("username"), null)
+        analytics.identify("userId")
+
+        assertThat(traits.userId()).isEqualTo("userId")
+        assertThat(traits.username()).isEqualTo("username")
+    }
+
+    @Test
     @Nullable
     fun invalidGroup() {
         try {


### PR DESCRIPTION
LIBMOBILE-49: https://segment.atlassian.net/browse/LIBMOBILE-49

### Things that couldn't be tested:
analytics.identify(null) throws an IllegalArgumentException so that couldn't be tested for resetting traits (there is an existing unit test for this).
analytics.identify() cannot be tested since the command requires at least one parameter.
analytics.identify("userId") will not have null traits since userId is a trait.

### New tests:
Test identifyNullTraits makes sure that when a userId is given, other traits aren't set (tested with username)
Test identifySavesPreviousTraits makes sure that when traits are defined under a userId they carry over when an identify call with only that userId is given.
