### PR TITLE
changed timestamp comments to reflect its behavior in android

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -225,10 +225,10 @@ public abstract class BasePayload extends ValueMap {
         }
 
         /**
-         * Set a timestamp for the event. By default, the current timestamp is used, but you may
-         * override it for historical import.
+         * Attach a library-created timestamp to historically import data to the Segment API.
          *
-         * <p>This library will automatically create and attach a timestamp to all events.
+         * <p>This library will automatically create and attach a timestamp to all events. This
+         * timestamp cannot be manually set when using the Segment Source in device mode.
          *
          * @see <a href="https://segment.com/docs/spec/common/#timestamps">Timestamp</a>
          */


### PR DESCRIPTION
Updated the comments on the behavior of `timestamp` in accordance with this ticket: https://segment.atlassian.net/browse/LIBMOBILE-56

Originally the comments implied the user could manually set `timestamp`, but that isn't true when using client-side libraries so I changed the comments to explicitly state it.