### PR TITLE
Make new lifecycle methods opt-out

### DIFF
--- a/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
+++ b/analytics-samples/analytics-sample/src/main/java/com/segment/analytics/sample/SampleApp.java
@@ -98,6 +98,7 @@ public class SampleApp extends Application {
                                                 return;
                                             }
                                         }
+                                        chain.proceed(chain.payload());
                                     }
                                 })
                         .flushQueueSize(1)

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -149,6 +149,7 @@ public class Analytics {
     volatile boolean shutdown;
 
     @Private final boolean nanosecondTimestamps;
+    @Private final boolean useNewLifecycleMethods;
 
     /**
      * Return a reference to the global default {@link Analytics} instance.
@@ -235,7 +236,8 @@ public class Analytics {
             JSMiddleware edgeFunctionMiddleware,
             @NonNull final ValueMap defaultProjectSettings,
             @NonNull Lifecycle lifecycle,
-            boolean nanosecondTimestamps) {
+            boolean nanosecondTimestamps,
+            boolean useNewLifecycleMethods) {
         this.application = application;
         this.networkExecutor = networkExecutor;
         this.stats = stats;
@@ -260,6 +262,7 @@ public class Analytics {
         this.edgeFunctionMiddleware = edgeFunctionMiddleware;
         this.lifecycle = lifecycle;
         this.nanosecondTimestamps = nanosecondTimestamps;
+        this.useNewLifecycleMethods = useNewLifecycleMethods;
 
         namespaceSharedPreferences();
 
@@ -327,10 +330,13 @@ public class Analytics {
                         .trackDeepLinks(trackDeepLinks)
                         .shouldRecordScreenViews(shouldRecordScreenViews)
                         .packageInfo(getPackageInfo(application))
+                        .useNewLifecycleMethods(useNewLifecycleMethods)
                         .build();
 
         application.registerActivityLifecycleCallbacks(activityLifecycleCallback);
-        lifecycle.addObserver(activityLifecycleCallback);
+        if (useNewLifecycleMethods) {
+            lifecycle.addObserver(activityLifecycleCallback);
+        }
     }
 
     @Private
@@ -975,7 +981,10 @@ public class Analytics {
             return;
         }
         application.unregisterActivityLifecycleCallbacks(activityLifecycleCallback);
-        lifecycle.removeObserver(activityLifecycleCallback);
+        if (useNewLifecycleMethods) {
+            // only unregister if feature is enabled
+            lifecycle.removeObserver(activityLifecycleCallback);
+        }
         // Only supplied by us for testing, so it's ok to shut it down. If we were to make this
         // public,
         // we'll have to add a check similar to that of AnalyticsNetworkExecutorService below.
@@ -1058,6 +1067,7 @@ public class Analytics {
         private boolean nanosecondTimestamps = false;
         private Crypto crypto;
         private ValueMap defaultProjectSettings = new ValueMap();
+        private boolean useNewLifecycleMethods = true; // opt-out feature
 
         /** Start building a new {@link Analytics} instance. */
         public Builder(Context context, String writeKey) {
@@ -1349,6 +1359,12 @@ public class Analytics {
             return this;
         }
 
+        /** Enable/Disable the use of the new Lifecycle Observer methods. Enabled by default. */
+        public Builder experimentalUseNewLifecycleMethods(boolean useNewLifecycleMethods) {
+            this.useNewLifecycleMethods = useNewLifecycleMethods;
+            return this;
+        }
+
         /**
          * Set the default project settings to use, if Segment.com cannot be reached. An example
          * configuration can be found here, using your write key: <a
@@ -1482,7 +1498,8 @@ public class Analytics {
                     edgeFunctionMiddleware,
                     defaultProjectSettings,
                     lifecycle,
-                    nanosecondTimestamps);
+                    nanosecondTimestamps,
+                    useNewLifecycleMethods);
         }
     }
 

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -189,9 +189,6 @@ class AnalyticsActivityLifecycleCallbacks
         if (shouldRecordScreenViews) {
             analytics.recordScreenViews(activity);
         }
-        if (!useNewLifecycleMethods) {
-            onStart(stubOwner);
-        }
         analytics.runOnMainThread(IntegrationOperation.onActivityStarted(activity));
     }
 

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -31,6 +31,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -49,13 +51,47 @@ class AnalyticsActivityLifecycleCallbacks
     private AtomicInteger numberOfActivities;
     private AtomicBoolean firstLaunch;
 
+    private AtomicBoolean isChangingActivityConfigurations;
+    private Boolean useNewLifecycleMethods;
+
+    // This is just a stub LifecycleOwner which is used when we need to call some lifecycle
+    // methods without going through the actual lifecycle callbacks
+    private static LifecycleOwner stubOwner =
+            new LifecycleOwner() {
+                Lifecycle stubLifecycle =
+                        new Lifecycle() {
+                            @Override
+                            public void addObserver(@NonNull LifecycleObserver observer) {
+                                // NO-OP
+                            }
+
+                            @Override
+                            public void removeObserver(@NonNull LifecycleObserver observer) {
+                                // NO-OP
+                            }
+
+                            @NonNull
+                            @Override
+                            public Lifecycle.State getCurrentState() {
+                                return State.DESTROYED;
+                            }
+                        };
+
+                @NonNull
+                @Override
+                public Lifecycle getLifecycle() {
+                    return stubLifecycle;
+                }
+            };
+
     private AnalyticsActivityLifecycleCallbacks(
             Analytics analytics,
             ExecutorService analyticsExecutor,
             Boolean shouldTrackApplicationLifecycleEvents,
             Boolean trackDeepLinks,
             Boolean shouldRecordScreenViews,
-            PackageInfo packageInfo) {
+            PackageInfo packageInfo,
+            Boolean useNewLifecycleMethods) {
         this.trackedApplicationLifecycleEvents = new AtomicBoolean(false);
         this.numberOfActivities = new AtomicInteger(1);
         this.firstLaunch = new AtomicBoolean(false);
@@ -65,12 +101,16 @@ class AnalyticsActivityLifecycleCallbacks
         this.trackDeepLinks = trackDeepLinks;
         this.shouldRecordScreenViews = shouldRecordScreenViews;
         this.packageInfo = packageInfo;
+        this.useNewLifecycleMethods = useNewLifecycleMethods;
+        this.isChangingActivityConfigurations = new AtomicBoolean(false);
     }
 
     @Override
     public void onStop(@NonNull LifecycleOwner owner) {
         // App in background
-        if (shouldTrackApplicationLifecycleEvents) {
+        if (shouldTrackApplicationLifecycleEvents
+                && numberOfActivities.decrementAndGet() == 0
+                && !isChangingActivityConfigurations.get()) {
             analytics.track("Application Backgrounded");
         }
     }
@@ -78,7 +118,9 @@ class AnalyticsActivityLifecycleCallbacks
     @Override
     public void onStart(@NonNull LifecycleOwner owner) {
         // App in foreground
-        if (shouldTrackApplicationLifecycleEvents) {
+        if (shouldTrackApplicationLifecycleEvents
+                && numberOfActivities.incrementAndGet() == 1
+                && !isChangingActivityConfigurations.get()) {
             Properties properties = new Properties();
             if (firstLaunch.get()) {
                 properties
@@ -114,6 +156,10 @@ class AnalyticsActivityLifecycleCallbacks
     public void onActivityCreated(Activity activity, Bundle bundle) {
         analytics.runOnMainThread(IntegrationOperation.onActivityCreated(activity, bundle));
 
+        if (!useNewLifecycleMethods) {
+            onCreate(stubOwner);
+        }
+
         if (trackDeepLinks) {
             trackDeepLink(activity);
         }
@@ -143,22 +189,34 @@ class AnalyticsActivityLifecycleCallbacks
         if (shouldRecordScreenViews) {
             analytics.recordScreenViews(activity);
         }
+        if (!useNewLifecycleMethods) {
+            onStart(stubOwner);
+        }
         analytics.runOnMainThread(IntegrationOperation.onActivityStarted(activity));
     }
 
     @Override
     public void onActivityResumed(Activity activity) {
         analytics.runOnMainThread(IntegrationOperation.onActivityResumed(activity));
+        if (!useNewLifecycleMethods) {
+            onStart(stubOwner);
+        }
     }
 
     @Override
     public void onActivityPaused(Activity activity) {
         analytics.runOnMainThread(IntegrationOperation.onActivityPaused(activity));
+        if (!useNewLifecycleMethods) {
+            onPause(stubOwner);
+        }
     }
 
     @Override
     public void onActivityStopped(Activity activity) {
         analytics.runOnMainThread(IntegrationOperation.onActivityStopped(activity));
+        if (!useNewLifecycleMethods) {
+            onStop(stubOwner);
+        }
     }
 
     @Override
@@ -170,6 +228,9 @@ class AnalyticsActivityLifecycleCallbacks
     @Override
     public void onActivityDestroyed(Activity activity) {
         analytics.runOnMainThread(IntegrationOperation.onActivityDestroyed(activity));
+        if (!useNewLifecycleMethods) {
+            onDestroy(stubOwner);
+        }
     }
 
     public static class Builder {
@@ -179,6 +240,7 @@ class AnalyticsActivityLifecycleCallbacks
         private Boolean trackDeepLinks;
         private Boolean shouldRecordScreenViews;
         private PackageInfo packageInfo;
+        private Boolean useNewLifecycleMethods;
 
         public Builder() {}
 
@@ -213,6 +275,11 @@ class AnalyticsActivityLifecycleCallbacks
             return this;
         }
 
+        Builder useNewLifecycleMethods(boolean useNewLifecycleMethods) {
+            this.useNewLifecycleMethods = useNewLifecycleMethods;
+            return this;
+        }
+
         public AnalyticsActivityLifecycleCallbacks build() {
             return new AnalyticsActivityLifecycleCallbacks(
                     analytics,
@@ -220,7 +287,8 @@ class AnalyticsActivityLifecycleCallbacks
                     shouldTrackApplicationLifecycleEvents,
                     trackDeepLinks,
                     shouldRecordScreenViews,
-                    packageInfo);
+                    packageInfo,
+                    useNewLifecycleMethods);
         }
     }
 }

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -1533,6 +1533,7 @@ open class AnalyticsTest {
         whenever(backgroundedActivity.isChangingConfigurations).thenReturn(false)
 
         callback.get().onCreate(mockLifecycleOwner)
+        callback.get().onStart(mockLifecycleOwner)
         callback.get().onResume(mockLifecycleOwner)
         callback.get().onStop(mockLifecycleOwner)
 
@@ -1621,6 +1622,224 @@ open class AnalyticsTest {
                             return payload.event() == "Application Opened" &&
                                 payload.properties()
                                     .getBoolean("from_background", false)
+                        }
+                    })
+            )
+    }
+
+    @Test
+    @Throws(NameNotFoundException::class)
+    open fun trackApplicationLifecycleEventsApplicationOpenedOldFlow() {
+        Analytics.INSTANCES.clear()
+        // need to reset bcos we interact with mock in our setUp function (implicitly via analytics
+        // constructor)
+        Mockito.reset(lifecycle)
+        val callback = AtomicReference<ActivityLifecycleCallbacks>()
+        doNothing()
+            .whenever(application)
+            .registerActivityLifecycleCallbacks(
+                argThat(
+                    object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
+                        override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
+                            callback.set(item)
+                            return true
+                        }
+                    })
+            )
+        analytics = Analytics(
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(Analytics.LogLevel.NONE),
+            "qaz",
+            listOf(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL.toLong(),
+            analyticsExecutor,
+            true,
+            CountDownLatch(0),
+            false,
+            false,
+            optOut,
+            Crypto.none(),
+            emptyList(),
+            emptyMap(),
+            jsMiddleware,
+            ValueMap(),
+            lifecycle,
+            false,
+            false
+        )
+
+        // Verify that new methods were not registered
+        verify(lifecycle, never()).addObserver(any(LifecycleObserver::class.java))
+        callback.get().onActivityCreated(null, null)
+        callback.get().onActivityResumed(null)
+        verify(integration)
+            .track(
+                argThat(
+                    object : NoDescriptionMatcher<TrackPayload>() {
+                        override fun matchesSafely(payload: TrackPayload): Boolean {
+                            return payload.event() == "Application Opened" &&
+                                payload.properties().getString("version") == "1.0.0" &&
+                                payload.properties().getString("build") == 100.toString() &&
+                                !payload.properties().getBoolean("from_background", true)
+                        }
+                    })
+            )
+    }
+
+    @Test
+    @Throws(NameNotFoundException::class)
+    open fun trackApplicationLifecycleEventsApplicationBackgroundedOldFlow() {
+        Analytics.INSTANCES.clear()
+        // need to reset bcos we interact with mock in our setUp function (implicitly via analytics
+        // constructor)
+        Mockito.reset(lifecycle)
+        val callback = AtomicReference<ActivityLifecycleCallbacks>()
+        doNothing()
+            .whenever(application)
+            .registerActivityLifecycleCallbacks(
+                argThat(
+                    object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
+                        override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
+                            callback.set(item)
+                            return true
+                        }
+                    })
+            )
+        analytics = Analytics(
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(Analytics.LogLevel.NONE),
+            "qaz",
+            listOf(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL.toLong(),
+            analyticsExecutor,
+            true,
+            CountDownLatch(0),
+            false,
+            false,
+            optOut,
+            Crypto.none(),
+            emptyList(),
+            emptyMap(),
+            jsMiddleware,
+            ValueMap(),
+            lifecycle,
+            false,
+            false
+        )
+
+        // Verify that new methods were not registered
+        verify(lifecycle, never()).addObserver(any(LifecycleObserver::class.java))
+        val backgroundedActivity: Activity = Mockito.mock(Activity::class.java)
+        whenever(backgroundedActivity.isChangingConfigurations).thenReturn(false)
+        callback.get().onActivityCreated(null, null)
+        callback.get().onActivityResumed(null)
+        callback.get().onActivityStopped(backgroundedActivity)
+        verify(integration)
+            .track(
+                argThat(
+                    object : NoDescriptionMatcher<TrackPayload>() {
+                        override fun matchesSafely(payload: TrackPayload): Boolean {
+                            return payload.event() == "Application Backgrounded"
+                        }
+                    })
+            )
+    }
+
+    @Test
+    @Throws(NameNotFoundException::class)
+    open fun trackApplicationLifecycleEventsApplicationForegroundedOldFlow() {
+        Analytics.INSTANCES.clear()
+        // need to reset bcos we interact with mock in our setUp function (implicitly via analytics
+        // constructor)
+        Mockito.reset(lifecycle)
+        val callback = AtomicReference<ActivityLifecycleCallbacks>()
+        doNothing()
+            .whenever(application)
+            .registerActivityLifecycleCallbacks(
+                argThat<ActivityLifecycleCallbacks>(
+                    object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
+                        override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
+                            callback.set(item)
+                            return true
+                        }
+                    })
+            )
+        analytics = Analytics(
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(Analytics.LogLevel.NONE),
+            "qaz",
+            listOf(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL.toLong(),
+            analyticsExecutor,
+            true,
+            CountDownLatch(0),
+            false,
+            false,
+            optOut,
+            Crypto.none(),
+            emptyList(),
+            emptyMap(),
+            jsMiddleware,
+            ValueMap(),
+            lifecycle,
+            false,
+            false
+        )
+
+        // Verify that new methods were not registered
+        verify(lifecycle, never()).addObserver(any(LifecycleObserver::class.java))
+        val backgroundedActivity: Activity = Mockito.mock(Activity::class.java)
+        whenever(backgroundedActivity.isChangingConfigurations).thenReturn(false)
+        callback.get().onActivityCreated(null, null)
+        callback.get().onActivityResumed(null)
+        callback.get().onActivityStopped(backgroundedActivity)
+        callback.get().onActivityResumed(null)
+        verify(integration)
+            .track(
+                argThat(
+                    object : NoDescriptionMatcher<TrackPayload>() {
+                        override fun matchesSafely(payload: TrackPayload): Boolean {
+                            return payload.event() == "Application Backgrounded"
+                        }
+                    })
+            )
+        verify(integration)
+            .track(
+                argThat(
+                    object : NoDescriptionMatcher<TrackPayload>() {
+                        override fun matchesSafely(payload: TrackPayload): Boolean {
+                            return payload.event() == "Application Opened" &&
+                                payload.properties().getBoolean("from_background", false)
                         }
                     })
             )

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -200,7 +200,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         // Used by singleton tests.
@@ -866,7 +867,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -953,7 +955,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -1021,7 +1024,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1091,7 +1095,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         val expectedURL = "app://track.com/open?utm_id=12345&gclid=abcd&nope="
@@ -1166,7 +1171,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         val expectedURL = "app://track.com/open?utm_id=12345&gclid=abcd&nope="
@@ -1239,7 +1245,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1303,7 +1310,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1371,7 +1379,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1448,7 +1457,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -1515,7 +1525,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         val backgroundedActivity = Mockito.mock(Activity::class.java)
@@ -1583,7 +1594,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -1670,7 +1682,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         assertThat(analytics.shutdown).isFalse()
@@ -1765,7 +1778,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         assertThat(analytics.shutdown).isFalse()
@@ -1834,7 +1848,8 @@ open class AnalyticsTest {
             jsMiddleware,
             defaultProjectSettings,
             lifecycle,
-            false
+            false,
+            true
         )
 
         assertThat(analytics.projectSettings).hasSize(2)
@@ -1878,7 +1893,8 @@ open class AnalyticsTest {
             jsMiddleware,
             defaultProjectSettings,
             lifecycle,
-            false
+            false,
+            true
         )
 
         assertThat(analytics.projectSettings).hasSize(2)
@@ -1931,7 +1947,8 @@ open class AnalyticsTest {
             jsMiddleware,
             defaultProjectSettings,
             lifecycle,
-            false
+            false,
+            true
         )
 
         assertThat(analytics.projectSettings).hasSize(2)
@@ -1996,6 +2013,7 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
+            true,
             true
         )
 
@@ -2034,7 +2052,8 @@ open class AnalyticsTest {
             jsMiddleware,
             ValueMap(),
             lifecycle,
-            false
+            false,
+            true
         )
 
         analytics.track("event")


### PR DESCRIPTION
Updated from #684 
This is a potential fix for issue currently faced by some android tv users.
This change doesnt completely remove the new lifecycle process, but rather allows switching between the new and legacy flow.
A new builder option useNewLifecycleMethods is introduced which defaults to true, and to opt-out of the new flow use
```java
Analytics.Builder builder =
        new Analytics.Builder(this, ANALYTICS_WRITE_KEY)
            ...
            .experimentalUseNewLifecycleMethods(false)
```

Implementation:
This code path controls the use of the new lifecycle flow: https://github.com/segmentio/analytics-android/pull/681/files#diff-a18a86eda368939313a371b220e906f0R331
If we circumvent ^ registration, then the onStart, onCreate, onStop functions in AnalyticsActivityLifecycleCallbacks wont get implicitly called, so we add these changes
https://github.com/segmentio/analytics-android/pull/681/files#diff-12bb80c3903ca5bd6c71fc44ea4ad80bR211
https://github.com/segmentio/analytics-android/pull/681/files#diff-12bb80c3903ca5bd6c71fc44ea4ad80bR197
https://github.com/segmentio/analytics-android/pull/681/files#diff-12bb80c3903ca5bd6c71fc44ea4ad80bR158
that will call the functions via the legacy lifecycle flow