### PR TITLE
Support custom host name for SegmentIntegration

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -45,6 +45,8 @@ import android.content.pm.PackageManager;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;
@@ -237,7 +239,8 @@ public class Analytics {
             @NonNull final ValueMap defaultProjectSettings,
             @NonNull Lifecycle lifecycle,
             boolean nanosecondTimestamps,
-            boolean useNewLifecycleMethods) {
+            boolean useNewLifecycleMethods,
+            String defaultApiHost) {
         this.application = application;
         this.networkExecutor = networkExecutor;
         this.stats = stats;
@@ -280,7 +283,8 @@ public class Analytics {
                             //     ...defaultProjectSettings.integrations
                             //     Segment.io: {
                             //       ...defaultProjectSettings.integrations.Segment.io
-                            //       apiKey: "{writeKey}"
+                            //       apiKey: "{writeKey}",
+                            //       apiHost: "{defaultApiHost}"
                             //     }
                             //   }
                             // }
@@ -308,6 +312,18 @@ public class Analytics {
                         if (edgeFunctionMiddleware != null) {
                             edgeFunctionMiddleware.setEdgeFunctionData(
                                     projectSettings.edgeFunctions());
+                        }
+                        boolean apiHostSet =
+                                projectSettings
+                                        .getValueMap("integrations")
+                                        .getValueMap("Segment.io")
+                                        .containsKey("apiHost");
+                        if (!apiHostSet) {
+                            // Use default apiHost region
+                            projectSettings
+                                    .getValueMap("integrations")
+                                    .getValueMap("Segment.io")
+                                    .putValue("apiHost", defaultApiHost);
                         }
                         HANDLER.post(
                                 new Runnable() {
@@ -1068,6 +1084,7 @@ public class Analytics {
         private Crypto crypto;
         private ValueMap defaultProjectSettings = new ValueMap();
         private boolean useNewLifecycleMethods = true; // opt-out feature
+        private String defaultApiHost = Utils.DEFAULT_API_HOST;
 
         /** Start building a new {@link Analytics} instance. */
         public Builder(Context context, String writeKey) {
@@ -1378,6 +1395,15 @@ public class Analytics {
         }
 
         /**
+         * Set the apiHost name for the region to which Segment sends events to. Defaults to
+         * "api.segment.io/v1"
+         */
+        public Builder defaultApiHost(String apiHost) {
+            this.defaultApiHost = apiHost;
+            return this;
+        }
+
+        /**
          * The executor on which payloads are dispatched asynchronously. This is not exposed
          * publicly.
          */
@@ -1499,7 +1525,8 @@ public class Analytics {
                     defaultProjectSettings,
                     lifecycle,
                     nanosecondTimestamps,
-                    useNewLifecycleMethods);
+                    useNewLifecycleMethods,
+                    defaultApiHost);
         }
     }
 

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -45,8 +45,6 @@ import android.content.pm.PackageManager;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.lifecycle.Lifecycle;

--- a/analytics/src/main/java/com/segment/analytics/Client.java
+++ b/analytics/src/main/java/com/segment/analytics/Client.java
@@ -97,8 +97,8 @@ class Client {
         this.connectionFactory = connectionFactory;
     }
 
-    Connection upload() throws IOException {
-        HttpURLConnection connection = connectionFactory.upload(writeKey);
+    Connection upload(String apiHost) throws IOException {
+        HttpURLConnection connection = connectionFactory.upload(apiHost, writeKey);
         return createPostConnection(connection);
     }
 

--- a/analytics/src/main/java/com/segment/analytics/ConnectionFactory.java
+++ b/analytics/src/main/java/com/segment/analytics/ConnectionFactory.java
@@ -54,8 +54,8 @@ public class ConnectionFactory {
      * Return a {@link HttpURLConnection} that writes batched payloads to {@code
      * https://api.segment.io/v1/import}.
      */
-    public HttpURLConnection upload(String writeKey) throws IOException {
-        HttpURLConnection connection = openConnection("https://api.segment.io/v1/import");
+    public HttpURLConnection upload(String apiHost, String writeKey) throws IOException {
+        HttpURLConnection connection = openConnection(String.format("https://%s/import", apiHost));
         connection.setRequestProperty("Authorization", authorizationHeader(writeKey));
         connection.setRequestProperty("Content-Encoding", "gzip");
         connection.setDoOutput(true);
@@ -64,7 +64,7 @@ public class ConnectionFactory {
     }
 
     /**
-     * Configures defaults for connections opened with {@link #upload(String)}, and {@link
+     * Configures defaults for connections opened with {@link #upload(String, String)}, and {@link
      * #projectSettings(String)}.
      */
     protected HttpURLConnection openConnection(String url) throws IOException {

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -80,6 +80,7 @@ public final class Utils {
     public static final int DEFAULT_FLUSH_INTERVAL = 30 * 1000; // 30s
     public static final int DEFAULT_FLUSH_QUEUE_SIZE = 20;
     public static final boolean DEFAULT_COLLECT_DEVICE_ID = true;
+    public static final String DEFAULT_API_HOST = "api.segment.io/v1";
 
     /** Creates a mutable HashSet instance containing the given elements in unspecified order */
     public static <T> Set<T> newSet(T... values) {

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -58,6 +58,7 @@ import com.segment.analytics.integrations.Logger
 import com.segment.analytics.integrations.ScreenPayload
 import com.segment.analytics.integrations.TrackPayload
 import com.segment.analytics.internal.Utils.AnalyticsNetworkExecutorService
+import com.segment.analytics.internal.Utils.DEFAULT_API_HOST
 import com.segment.analytics.internal.Utils.DEFAULT_FLUSH_INTERVAL
 import com.segment.analytics.internal.Utils.DEFAULT_FLUSH_QUEUE_SIZE
 import com.segment.analytics.internal.Utils.isNullOrEmpty
@@ -97,6 +98,8 @@ open class AnalyticsTest {
             |  "integrations": {
             |    "test": { 
             |      "foo": "bar"
+            |    },
+            |    "Segment.io": {
             |    }
             |  },
             | "plan": {
@@ -201,7 +204,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         // Used by singleton tests.
@@ -868,7 +872,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -956,7 +961,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -1025,7 +1031,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1096,7 +1103,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         val expectedURL = "app://track.com/open?utm_id=12345&gclid=abcd&nope="
@@ -1172,7 +1180,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         val expectedURL = "app://track.com/open?utm_id=12345&gclid=abcd&nope="
@@ -1246,7 +1255,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1311,7 +1321,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1380,7 +1391,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         val activity = Mockito.mock(Activity::class.java)
@@ -1458,7 +1470,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -1526,7 +1539,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         val backgroundedActivity = Mockito.mock(Activity::class.java)
@@ -1596,7 +1610,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         callback.get().onCreate(mockLifecycleOwner)
@@ -1675,7 +1690,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            false
+            false,
+            DEFAULT_API_HOST
         )
 
         // Verify that new methods were not registered
@@ -1744,7 +1760,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            false
+            false,
+            DEFAULT_API_HOST
         )
 
         // Verify that new methods were not registered
@@ -1813,7 +1830,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            false
+            false,
+            DEFAULT_API_HOST
         )
 
         // Verify that new methods were not registered
@@ -1902,7 +1920,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         assertThat(analytics.shutdown).isFalse()
@@ -1998,7 +2017,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         assertThat(analytics.shutdown).isFalse()
@@ -2068,7 +2088,8 @@ open class AnalyticsTest {
             defaultProjectSettings,
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         assertThat(analytics.projectSettings).hasSize(2)
@@ -2113,7 +2134,8 @@ open class AnalyticsTest {
             defaultProjectSettings,
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         assertThat(analytics.projectSettings).hasSize(2)
@@ -2167,7 +2189,8 @@ open class AnalyticsTest {
             defaultProjectSettings,
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         assertThat(analytics.projectSettings).hasSize(2)
@@ -2175,9 +2198,11 @@ open class AnalyticsTest {
         assertThat(analytics.projectSettings.integrations()).containsKey("Segment.io")
         assertThat(analytics.projectSettings.integrations()).hasSize(1)
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
-            .hasSize(3)
+            .hasSize(4)
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
             .containsKey("apiKey")
+        assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
+                .containsKey("apiHost")
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
             .containsKey("appToken")
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
@@ -2233,7 +2258,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             true,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         analytics.track("event")
@@ -2254,7 +2280,8 @@ open class AnalyticsTest {
             analyticsContext,
             defaultOptions,
             Logger.with(Analytics.LogLevel.NONE),
-            "qaz", listOf(factory),
+            "qaz",
+            listOf(factory),
             client,
             Cartographer.INSTANCE,
             projectSettingsCache,
@@ -2272,7 +2299,8 @@ open class AnalyticsTest {
             ValueMap(),
             lifecycle,
             false,
-            true
+            true,
+            DEFAULT_API_HOST
         )
 
         analytics.track("event")

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -2202,7 +2202,7 @@ open class AnalyticsTest {
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
             .containsKey("apiKey")
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
-                .containsKey("apiHost")
+            .containsKey("apiHost")
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))
             .containsKey("appToken")
         assertThat(analytics.projectSettings.integrations().getValueMap("Segment.io"))

--- a/analytics/src/test/java/com/segment/analytics/ClientTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/ClientTest.kt
@@ -51,6 +51,11 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 class ClientTest {
+
+    companion object {
+        const val DEFAULT_API_HOST = "api.segment.io/v1"
+    }
+
     @Rule @JvmField val server = MockWebServer()
     @Rule @JvmField val folder = TemporaryFolder()
     private lateinit var client: Client
@@ -89,7 +94,7 @@ class ClientTest {
     fun upload() {
         server.enqueue(MockResponse())
 
-        val connection = client.upload()
+        val connection = client.upload(DEFAULT_API_HOST)
         assertThat(connection.os).isNotNull()
         assertThat(connection.`is`).isNull()
         assertThat(connection.connection.responseCode).isEqualTo(200) // consume the response
@@ -108,7 +113,7 @@ class ClientTest {
         whenever(mockConnection.outputStream).thenReturn(os)
         whenever(mockConnection.responseCode).thenReturn(200)
 
-        val connection = mockClient.upload()
+        val connection = mockClient.upload(DEFAULT_API_HOST)
         verify(mockConnection).doOutput = true
         verify(mockConnection).setChunkedStreamingMode(0)
 
@@ -124,7 +129,7 @@ class ClientTest {
         whenever(mockConnection.outputStream).thenReturn(os)
         whenever(mockConnection.responseCode).thenReturn(202)
 
-        val connection = mockClient.upload()
+        val connection = mockClient.upload(DEFAULT_API_HOST)
         verify(mockConnection).doOutput = true
         verify(mockConnection).setChunkedStreamingMode(0)
 
@@ -143,7 +148,7 @@ class ClientTest {
         whenever(mockConnection.responseMessage).thenReturn("bar")
         whenever(mockConnection.inputStream).thenReturn(input)
 
-        val connection = mockClient.upload()
+        val connection = mockClient.upload(DEFAULT_API_HOST)
         verify(mockConnection).doOutput = true
         verify(mockConnection).setChunkedStreamingMode(0)
 
@@ -173,7 +178,7 @@ class ClientTest {
         whenever(mockConnection.inputStream).thenThrow(FileNotFoundException())
         whenever(mockConnection.errorStream).thenReturn(input)
 
-        val connection = mockClient.upload()
+        val connection = mockClient.upload(DEFAULT_API_HOST)
         verify(mockConnection).doOutput = true
         verify(mockConnection).setChunkedStreamingMode(0)
 

--- a/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/SegmentIntegrationTest.kt
@@ -78,6 +78,10 @@ import org.robolectric.shadows.ShadowLog
 @Config(manifest = Config.NONE)
 class SegmentIntegrationTest {
 
+    companion object {
+        const val DEFAULT_API_HOST = "api.segment.io/v1"
+    }
+
     @Rule @JvmField
     val folder = TemporaryFolder()
     private lateinit var queueFile: QueueFile
@@ -205,7 +209,7 @@ class SegmentIntegrationTest {
         val payloadQueue = PersistentQueue(queueFile)
         val client = mock(Client::class.java)
         val connection = mockConnection()
-        whenever(client.upload()).thenReturn(connection)
+        whenever(client.upload(DEFAULT_API_HOST)).thenReturn(connection)
         val segmentIntegration =
             SegmentBuilder()
                 .client(client)
@@ -219,7 +223,7 @@ class SegmentIntegrationTest {
         // Only the last enqueue should trigger an upload.
         segmentIntegration.performEnqueue(TRACK_PAYLOAD)
 
-        verify(client).upload()
+        verify(client).upload(DEFAULT_API_HOST)
     }
 
     @Test
@@ -227,7 +231,7 @@ class SegmentIntegrationTest {
     fun flushRemovesItemsFromQueue() {
         val payloadQueue = PersistentQueue(queueFile)
         val client = mock(Client::class.java)
-        whenever(client.upload()).thenReturn(mockConnection())
+        whenever(client.upload(DEFAULT_API_HOST)).thenReturn(mockConnection())
         val segmentIntegration =
             SegmentBuilder()
                 .client(client)
@@ -292,7 +296,7 @@ class SegmentIntegrationTest {
 
         segmentIntegration.submitFlush()
 
-        verify(client, never()).upload()
+        verify(client, never()).upload(DEFAULT_API_HOST)
     }
 
     @Test
@@ -311,7 +315,7 @@ class SegmentIntegrationTest {
         segmentIntegration.submitFlush()
 
         verifyZeroInteractions(context)
-        verify(client, never()).upload()
+        verify(client, never()).upload(DEFAULT_API_HOST)
     }
 
     @Test
@@ -322,7 +326,7 @@ class SegmentIntegrationTest {
         queueFile.add(TRACK_PAYLOAD_JSON.toByteArray())
         val urlConnection = mock(HttpURLConnection::class.java)
         val connection = mockConnection(urlConnection)
-        whenever(client.upload()).thenReturn(connection)
+        whenever(client.upload(DEFAULT_API_HOST)).thenReturn(connection)
         val segmentIntegration =
             SegmentBuilder()
                 .client(client)
@@ -340,7 +344,7 @@ class SegmentIntegrationTest {
         // todo: rewrite using mockwebserver.
         val client = mock(Client::class.java)
         val payloadQueue = PersistentQueue(queueFile)
-        whenever(client.upload())
+        whenever(client.upload(DEFAULT_API_HOST))
             .thenReturn(
                 object : Client.Connection(
                     mock(HttpURLConnection::class.java), mock(InputStream::class.java), mock(OutputStream::class.java)
@@ -362,7 +366,7 @@ class SegmentIntegrationTest {
         segmentIntegration.submitFlush()
 
         assertThat(queueFile.size()).isEqualTo(0)
-        verify(client).upload()
+        verify(client).upload(DEFAULT_API_HOST)
     }
 
     @Test
@@ -371,7 +375,7 @@ class SegmentIntegrationTest {
         // todo: rewrite using mockwebserver.
         val payloadQueue: PayloadQueue = PersistentQueue(queueFile)
         val client = mock(Client::class.java)
-        whenever(client.upload())
+        whenever(client.upload(DEFAULT_API_HOST))
             .thenReturn(
                 object : Client.Connection(
                     mock(HttpURLConnection::class.java), mock(InputStream::class.java), mock(OutputStream::class.java)
@@ -392,7 +396,7 @@ class SegmentIntegrationTest {
         }
         segmentIntegration.submitFlush()
         assertThat(queueFile.size()).isEqualTo(4)
-        verify(client).upload()
+        verify(client).upload(DEFAULT_API_HOST)
     }
 
     @Test
@@ -401,7 +405,7 @@ class SegmentIntegrationTest {
         // todo: rewrite using mockwebserver.
         val payloadQueue: PayloadQueue = PersistentQueue(queueFile)
         val client = mock(Client::class.java)
-        whenever(client.upload())
+        whenever(client.upload(DEFAULT_API_HOST))
             .thenReturn(
                 object : Client.Connection(
                     mock(
@@ -426,7 +430,7 @@ class SegmentIntegrationTest {
 
         // Verify that messages were not removed from the queue when server returned a 429.
         assertThat(queueFile.size()).isEqualTo(4)
-        verify(client).upload()
+        verify(client).upload(DEFAULT_API_HOST)
     }
 
     @Test
@@ -650,7 +654,8 @@ class SegmentIntegrationTest {
                 flushInterval.toLong(),
                 flushSize,
                 logger,
-                Crypto.none()
+                Crypto.none(),
+                DEFAULT_API_HOST
             )
         }
     }


### PR DESCRIPTION
In our efforts to support data residency, these changes allow our SDK to retrieve a custom apiHost name from `settings` and also provides a new builder option to provide a `defaultApiHost()`.

The host name can be configured via `app.segment.com` under the individual source's settings. 
If the SDK were to fail while fetching `settings` from the internet, we use the `defaultApiHost` property for configuration

Usage
```java
Analytics.Builder(this, ANALYTICS_WRITE_KEY)
             .defaultApiHost("api.segment.io/v1")
```