### PR TITLE
fix java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user is unlocked by using device protected storage for segment shared preferences

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -308,7 +308,8 @@ public final class Utils {
 
     /** Returns a shared preferences for storing any library preferences. */
     public static SharedPreferences getSegmentSharedPreferences(Context context, String tag) {
-        return context.getSharedPreferences("analytics-android-" + tag, MODE_PRIVATE);
+        return obtainDeviceProtectedStorageContext(context)
+                .getSharedPreferences("analytics-android-" + tag, MODE_PRIVATE);
     }
 
     /** Get the string resource for the given key. Returns null if not found. */
@@ -530,6 +531,16 @@ public final class Utils {
             }
         }
         editor.apply();
+    }
+
+    private static Context obtainDeviceProtectedStorageContext(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            // All N devices have split storage areas, but we may need to recreate the preferences in the new device
+            // protected storage area, which is where the data lives from now on.
+            return context.createDeviceProtectedStorageContext();
+        } else {
+            return context;
+        }
     }
 
     private Utils() {


### PR DESCRIPTION
fix java.lang.IllegalStateException: SharedPreferences in credential encrypted storage are not available until after user is unlocked by using device protected storage for segment shared preferences.
[Issue tracked her.](https://github.com/segmentio/analytics-android/issues/741)

The issue reproduces when we try to send any analytics with segment lib from a scheduled job or from push notification handling while device is in booted but locked state. Meaning, user turned on the device, but hasn't unlock the device at least once. At this moment only device protected storage is available, but default storage that is used in current implementation - credentials protected storage which is only available when user unlocks the device.

The fix is pretty much adapted Google solution they propose in their [directBoot example app](https://github.com/googlearchive/android-DirectBoot/blob/737ab9a214debbf3c940360b834077ccc3035ff3/Application/src/main/java/com/example/android/directboot/alarms/AlarmStorage.java).