### PR TITLE
Remove irrelevant tests for null write-keys

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -62,9 +62,6 @@ import com.segment.analytics.internal.NanoDate;
 import com.segment.analytics.internal.Private;
 import com.segment.analytics.internal.Utils;
 import com.segment.analytics.internal.Utils.AnalyticsNetworkExecutorService;
-
-import org.jetbrains.annotations.NotNull;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -78,6 +75,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The entry point into the Segment for Android SDK.
@@ -1091,9 +1089,8 @@ public class Analytics {
         /**
          * Start building a new {@link Analytics} instance.
          *
-         * Throws {@link IllegalArgumentException} in following cases:
-         * - no INTERNET permission granted
-         * - writeKey is empty
+         * <p>Throws {@link IllegalArgumentException} in following cases: - no INTERNET permission
+         * granted - writeKey is empty
          */
         public Builder(@NotNull Context context, @NotNull String writeKey) {
             if (!hasPermission(context, Manifest.permission.INTERNET)) {

--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -30,7 +30,7 @@ import static com.segment.analytics.internal.Utils.getResourceString;
 import static com.segment.analytics.internal.Utils.getSegmentSharedPreferences;
 import static com.segment.analytics.internal.Utils.hasPermission;
 import static com.segment.analytics.internal.Utils.immutableCopyOf;
-import static com.segment.analytics.internal.Utils.isEmpty;
+import static com.segment.analytics.internal.Utils.isEmptyOrBlank;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
 
 import android.Manifest;
@@ -1100,7 +1100,7 @@ public class Analytics {
                 throw new IllegalArgumentException("INTERNET permission is required.");
             }
             application = (Application) context.getApplicationContext();
-            if (isEmpty(writeKey)) {
+            if (isEmptyOrBlank(writeKey)) {
                 throw new IllegalArgumentException("writeKey must not be empty.");
             }
             this.writeKey = writeKey;

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -74,6 +74,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -201,6 +203,16 @@ public final class Utils {
      */
     public static boolean isEmpty(@Nullable CharSequence str) {
         return str == null || str.length() == 0;
+    }
+
+    /**
+     * Returns true if the string is empty (once trimmed).
+     *
+     * @param str the string to be examined
+     * @return true if the string is empty (once trimmed) or 0-length
+     */
+    public static boolean isEmptyOrBlank(@NotNull CharSequence str) {
+        return str.length() == 0 || getTrimmedLength(str) == 0;
     }
 
     /**

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -45,10 +45,8 @@ import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.segment.analytics.Analytics;
 import com.segment.analytics.integrations.Logger;
-
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
@@ -74,7 +72,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -88,7 +85,7 @@ public final class Utils {
     public static final boolean DEFAULT_COLLECT_DEVICE_ID = true;
     public static final String DEFAULT_API_HOST = "api.segment.io/v1";
 
-    private final static int PERMISSION_CHECK_REPEAT_MAX_COUNT = 2;
+    private static final int PERMISSION_CHECK_REPEAT_MAX_COUNT = 2;
     private static final Logger logger = Logger.with(Analytics.LogLevel.DEBUG);
 
     /** Creates a mutable HashSet instance containing the given elements in unspecified order */

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsBuilderTest.kt
@@ -39,6 +39,7 @@ import org.assertj.core.api.Assertions.fail
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
@@ -62,13 +63,6 @@ class AnalyticsBuilderTest {
     @Test
     @Throws(Exception::class)
     fun invalidContextThrowsException() {
-        try {
-            Builder(null, null)
-            fail("Null context should throw exception.")
-        } catch (expected: IllegalArgumentException) {
-            assertThat(expected).hasMessage("Context must not be null.")
-        }
-
         whenever(context.checkCallingOrSelfPermission(INTERNET)).thenReturn(PERMISSION_DENIED)
         try {
             Builder(context, "foo")
@@ -147,44 +141,29 @@ class AnalyticsBuilderTest {
     @Throws(Exception::class)
     fun invalidWriteKeyThrowsException() {
         try {
-            Builder(context, null)
-            fail("Null writeKey should throw exception.")
-        } catch (expected: IllegalArgumentException) {
-            assertThat(expected).hasMessage("writeKey must not be null or empty.")
-        }
-
-        try {
             Builder(context, "")
             fail("Blank writeKey should throw exception.")
         } catch (expected: IllegalArgumentException) {
-            assertThat(expected).hasMessage("writeKey must not be null or empty.")
+            assertThat(expected).hasMessage("writeKey must not be empty.")
         }
 
         try {
             Builder(context, "    ")
             fail("Blank writeKey should throw exception.")
         } catch (expected: IllegalArgumentException) {
-            assertThat(expected).hasMessage("writeKey must not be null or empty.")
+            assertThat(expected).hasMessage("writeKey must not be empty.")
         }
     }
 
     @Test
     @Throws(Exception::class)
     fun invalidWriteKeyFromResourcesThrowsException() {
-        mockWriteKeyInResources(context, null)
-        try {
-            Analytics.with(context)
-            fail("Null writeKey should throw exception.")
-        } catch (expected: IllegalArgumentException) {
-            assertThat(expected).hasMessage("writeKey must not be null or empty.")
-        }
-
         mockWriteKeyInResources(context, "")
         try {
             Analytics.with(context)
             fail("Empty writeKey should throw exception.")
         } catch (expected: java.lang.IllegalArgumentException) {
-            assertThat(expected).hasMessage("writeKey must not be null or empty.")
+            assertThat(expected).hasMessage("writeKey must not be empty.")
         }
 
         mockWriteKeyInResources(context, "    ")
@@ -192,7 +171,7 @@ class AnalyticsBuilderTest {
             Analytics.with(context)
             fail("Blank writeKey should throw exception.")
         } catch (expected: java.lang.IllegalArgumentException) {
-            assertThat(expected).hasMessage("writeKey must not be null or empty.")
+            assertThat(expected).hasMessage("writeKey must not be empty.")
         }
     }
 
@@ -286,10 +265,10 @@ class AnalyticsBuilderTest {
         }
     }
 
-    private fun mockWriteKeyInResources(context: Context, writeKey: String?) {
+    private fun mockWriteKeyInResources(context: Context, writeKey: String) {
         val resources = Mockito.mock(Resources::class.java)
         whenever(context.resources).thenReturn(resources)
-        whenever(resources.getIdentifier(eq(WRITE_KEY_RESOURCE_IDENTIFIER), eq("string"), eq("string")))
+        whenever(resources.getIdentifier(eq(WRITE_KEY_RESOURCE_IDENTIFIER), eq("string"), any()))
             .thenReturn(1)
         whenever(resources.getString(1)).thenReturn(writeKey)
     }


### PR DESCRIPTION
Since #750 added `@NotNull` to write-key params, we can remove tests that test those edge cases.