### PR TITLE
Check Float NaN and Infinity

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Cartographer.java
+++ b/analytics/src/main/java/com/segment/analytics/Cartographer.java
@@ -216,6 +216,10 @@ public class Cartographer {
                     && (Double.isNaN((Double) value) || Double.isInfinite((Double) value))) {
                 value = 0.0;
             }
+            if (value instanceof Float
+                    && (Float.isNaN((Float) value) || Float.isInfinite((Float) value))) {
+                value = 0.0;
+            }
             writer.value((Number) value);
         } else if (value instanceof Boolean) {
             writer.value((Boolean) value);

--- a/analytics/src/test/java/com/segment/analytics/CartographerTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/CartographerTest.kt
@@ -321,6 +321,27 @@ class CartographerTest {
 
     @Test
     @Throws(IOException::class)
+    fun encodesInfiniteAndNanFloats() {
+        val map = ImmutableMap.builder<String, Any>()
+            .put("nan", Float.NaN)
+            .put("positive_infinity", Float.POSITIVE_INFINITY)
+            .put("negative_infinity", Float.NEGATIVE_INFINITY)
+            .build()
+
+        assertThat(cartographer.toJson(map))
+            .isEqualTo(
+                """
+                        |{
+                        |  "nan": 0.0,
+                        |  "positive_infinity": 0.0,
+                        |  "negative_infinity": 0.0
+                        |}
+                        """.trimMargin()
+            )
+    }
+
+    @Test
+    @Throws(IOException::class)
     fun encodesPrimitiveArrays() {
         // Exercise a bug where primitive arrays would throw an IOException.
         // https://github.com/segmentio/analytics-android/issues/507


### PR DESCRIPTION
Hi! I saw the [fix for NaN](https://github.com/segmentio/analytics-android/pull/752) values in the latest release. Thanks!

I checked the changes and saw the fix is implemented for Double only. We actually had this problem with Floats, so I tried it and Segment is still parsing them as NaN.

I replicated the fix for Doubles, and decided to send you a PR with it. I hope it helps!