### PR TITLE
Fix Incorrect Timestamps

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/Analytics.java
+++ b/analytics/src/main/java/com/segment/analytics/Analytics.java
@@ -64,6 +64,7 @@ import com.segment.analytics.internal.Utils;
 import com.segment.analytics.internal.Utils.AnalyticsNetworkExecutorService;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -474,7 +475,7 @@ public class Analytics {
         if (isNullOrEmpty(userId) && isNullOrEmpty(newTraits)) {
             throw new IllegalArgumentException("Either userId or some traits must be provided.");
         }
-        NanoDate timestamp = new NanoDate();
+        Date timestamp = this.nanosecondTimestamps ? new NanoDate() : new Date();
         analyticsExecutor.submit(
                 new Runnable() {
                     @Override
@@ -531,7 +532,7 @@ public class Analytics {
         if (isNullOrEmpty(groupId)) {
             throw new IllegalArgumentException("groupId must not be null or empty.");
         }
-        NanoDate timestamp = new NanoDate();
+        Date timestamp = this.nanosecondTimestamps ? new NanoDate() : new Date();
         analyticsExecutor.submit(
                 new Runnable() {
                     @Override
@@ -583,7 +584,7 @@ public class Analytics {
         if (isNullOrEmpty(event)) {
             throw new IllegalArgumentException("event must not be null or empty.");
         }
-        NanoDate timestamp = new NanoDate();
+        Date timestamp = this.nanosecondTimestamps ? new NanoDate() : new Date();
         analyticsExecutor.submit(
                 new Runnable() {
                     @Override
@@ -653,7 +654,7 @@ public class Analytics {
         if (isNullOrEmpty(category) && isNullOrEmpty(name)) {
             throw new IllegalArgumentException("either category or name must be provided.");
         }
-        NanoDate timestamp = new NanoDate();
+        Date timestamp = this.nanosecondTimestamps ? new NanoDate() : new Date();
         analyticsExecutor.submit(
                 new Runnable() {
                     @Override
@@ -708,7 +709,7 @@ public class Analytics {
             throw new IllegalArgumentException("newId must not be null or empty.");
         }
 
-        NanoDate timestamp = new NanoDate();
+        Date timestamp = this.nanosecondTimestamps ? new NanoDate() : new Date();
         analyticsExecutor.submit(
                 new Runnable() {
                     @Override

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -370,7 +370,11 @@ public abstract class BasePayload extends ValueMap {
             }
 
             if (timestamp == null) {
-                timestamp = new NanoDate(); // captures higher resolution timestamps
+                if (this.nanosecondTimestamps) {
+                    timestamp = new NanoDate(); // captures higher resolution timestamps
+                } else {
+                    timestamp = new Date();
+                }
             }
 
             if (isNullOrEmpty(context)) {

--- a/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
+++ b/analytics/src/main/java/com/segment/analytics/integrations/BasePayload.java
@@ -27,6 +27,7 @@ import static com.segment.analytics.internal.Utils.assertNotNull;
 import static com.segment.analytics.internal.Utils.assertNotNullOrEmpty;
 import static com.segment.analytics.internal.Utils.immutableCopyOf;
 import static com.segment.analytics.internal.Utils.isNullOrEmpty;
+import static com.segment.analytics.internal.Utils.parseISO8601Date;
 import static com.segment.analytics.internal.Utils.parseISO8601DateWithNanos;
 import static com.segment.analytics.internal.Utils.toISO8601NanoFormattedString;
 import static com.segment.analytics.internal.Utils.toISO8601String;
@@ -131,7 +132,11 @@ public abstract class BasePayload extends ValueMap {
         if (isNullOrEmpty(timestamp)) {
             return null;
         }
-        return parseISO8601DateWithNanos(timestamp);
+        if (timestamp.length() == "yyyy-MM-ddThh:mm:ss.fffZ".length()) {
+            return parseISO8601Date(timestamp);
+        } else {
+            return parseISO8601DateWithNanos(timestamp);
+        }
     }
 
     /**


### PR DESCRIPTION
As demonstrated in #757, timestamps are being reported incorrectly due to clock issues stemming from using `System.nanoTime()`. We are currently investigating on how to improve our nanosecond reporting, but since the issue is affecting the non-experimental features, this quick fix should hopefully put our regular SDK users back on track. 

_Note: Any continuing users of the `experimentalNanosecondTimestamps()` feature will still face the issue referenced in #757_