### PR TITLE
Safely handle bad URIs when tracking deep links

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -173,11 +173,15 @@ class AnalyticsActivityLifecycleCallbacks
 
         Properties properties = new Properties();
         Uri uri = intent.getData();
-        for (String parameter : uri.getQueryParameterNames()) {
-            String value = uri.getQueryParameter(parameter);
-            if (value != null && !value.trim().isEmpty()) {
-                properties.put(parameter, value);
+        try {
+            for (String parameter : uri.getQueryParameterNames()) {
+                String value = uri.getQueryParameter(parameter);
+                if (value != null && !value.trim().isEmpty()) {
+                    properties.put(parameter, value);
+                }
             }
+        } catch (Exception e) {
+            analytics.logger("LifecycleCallbacks").error(e, "failed to get uri params for %s", uri.toString());
         }
 
         properties.put("url", uri.toString());

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -181,7 +181,9 @@ class AnalyticsActivityLifecycleCallbacks
                 }
             }
         } catch (Exception e) {
-            analytics.logger("LifecycleCallbacks").error(e, "failed to get uri params for %s", uri.toString());
+            analytics
+                    .logger("LifecycleCallbacks")
+                    .error(e, "failed to get uri params for %s", uri.toString());
         }
 
         properties.put("url", uri.toString());

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -1215,48 +1215,48 @@ open class AnalyticsTest {
         Analytics.INSTANCES.clear()
 
         val callback =
-                AtomicReference<ActivityLifecycleCallbacks>()
+            AtomicReference<ActivityLifecycleCallbacks>()
 
         doNothing()
-                .whenever(application)
-                .registerActivityLifecycleCallbacks(
-                        argThat<ActivityLifecycleCallbacks>(
-                                object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
-                                    override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
-                                        callback.set(item)
-                                        return true
-                                    }
-                                })
-                )
+            .whenever(application)
+            .registerActivityLifecycleCallbacks(
+                argThat<ActivityLifecycleCallbacks>(
+                    object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
+                        override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
+                            callback.set(item)
+                            return true
+                        }
+                    })
+            )
 
         analytics = Analytics(
-                application,
-                networkExecutor,
-                stats,
-                traitsCache,
-                analyticsContext,
-                defaultOptions,
-                Logger.with(Analytics.LogLevel.NONE),
-                "qaz", listOf(factory),
-                client,
-                Cartographer.INSTANCE,
-                projectSettingsCache,
-                "foo",
-                DEFAULT_FLUSH_QUEUE_SIZE,
-                DEFAULT_FLUSH_INTERVAL.toLong(),
-                analyticsExecutor,
-                true,
-                CountDownLatch(0),
-                false,
-                false,
-                optOut,
-                Crypto.none(), emptyList(), emptyMap(),
-                jsMiddleware,
-                ValueMap(),
-                lifecycle,
-                false,
-                true,
-                DEFAULT_API_HOST
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(Analytics.LogLevel.NONE),
+            "qaz", listOf(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL.toLong(),
+            analyticsExecutor,
+            true,
+            CountDownLatch(0),
+            false,
+            false,
+            optOut,
+            Crypto.none(), emptyList(), emptyMap(),
+            jsMiddleware,
+            ValueMap(),
+            lifecycle,
+            false,
+            true,
+            DEFAULT_API_HOST
         )
 
         val expectedURL = "wc:foo-bar-jk@1bridge=https%3A%2F%2Fbridge.walletconnect.org&key=1234"
@@ -1269,16 +1269,16 @@ open class AnalyticsTest {
         whenever(activity.intent).thenReturn(intent)
 
         verify(integration, Mockito.never())
-                .track(
-                        argThat<TrackPayload>(
-                                object : NoDescriptionMatcher<TrackPayload>() {
-                                    override fun matchesSafely(payload: TrackPayload): Boolean {
-                                        return payload.event() == "Deep Link Opened" &&
-                                                payload.properties()
-                                                        .getString("url") == expectedURL
-                                    }
-                                })
-                )
+            .track(
+                argThat<TrackPayload>(
+                    object : NoDescriptionMatcher<TrackPayload>() {
+                        override fun matchesSafely(payload: TrackPayload): Boolean {
+                            return payload.event() == "Deep Link Opened" &&
+                                payload.properties()
+                                .getString("url") == expectedURL
+                        }
+                    })
+            )
     }
 
     @Test

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -1211,6 +1211,77 @@ open class AnalyticsTest {
     }
 
     @Test
+    fun trackDeepLinks_bad_uri() {
+        Analytics.INSTANCES.clear()
+
+        val callback =
+                AtomicReference<ActivityLifecycleCallbacks>()
+
+        doNothing()
+                .whenever(application)
+                .registerActivityLifecycleCallbacks(
+                        argThat<ActivityLifecycleCallbacks>(
+                                object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
+                                    override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
+                                        callback.set(item)
+                                        return true
+                                    }
+                                })
+                )
+
+        analytics = Analytics(
+                application,
+                networkExecutor,
+                stats,
+                traitsCache,
+                analyticsContext,
+                defaultOptions,
+                Logger.with(Analytics.LogLevel.NONE),
+                "qaz", listOf(factory),
+                client,
+                Cartographer.INSTANCE,
+                projectSettingsCache,
+                "foo",
+                DEFAULT_FLUSH_QUEUE_SIZE,
+                DEFAULT_FLUSH_INTERVAL.toLong(),
+                analyticsExecutor,
+                true,
+                CountDownLatch(0),
+                false,
+                false,
+                optOut,
+                Crypto.none(), emptyList(), emptyMap(),
+                jsMiddleware,
+                ValueMap(),
+                lifecycle,
+                false,
+                true,
+                DEFAULT_API_HOST
+        )
+
+        val expectedURL = "wc:foo-bar-jk@1bridge=https%3A%2F%2Fbridge.walletconnect.org&key=1234"
+
+        val activity = Mockito.mock(Activity::class.java)
+        val intent = Mockito.mock(Intent::class.java)
+        val uri = Uri.parse(expectedURL)
+
+        whenever(intent.data).thenReturn(uri)
+        whenever(activity.intent).thenReturn(intent)
+
+        verify(integration, Mockito.never())
+                .track(
+                        argThat<TrackPayload>(
+                                object : NoDescriptionMatcher<TrackPayload>() {
+                                    override fun matchesSafely(payload: TrackPayload): Boolean {
+                                        return payload.event() == "Deep Link Opened" &&
+                                                payload.properties()
+                                                        .getString("url") == expectedURL
+                                    }
+                                })
+                )
+    }
+
+    @Test
     fun trackDeepLinks_null() {
         Analytics.INSTANCES.clear()
 


### PR DESCRIPTION
as per #736, when tracking deep links with a bad URI it causes the app to crash. The error stems from android being able to accept a non-hierarchal URI for opening the app, but unable to parse the info using `getQueryParameterNames()`(eg of bad uri: `wc:f94d4c5b-a28e-a516-4fd7-2bf37eca3a9e@1bridge=https%3A%2F%2Fbridge.walletconnect.org&key=ccaac40bbc0b9bd17d6ee8ff58f3ccfe3e`)

This change will make it so that we do not crash the app, while tracking the deep link, but not parse any of the URI details

Closes #736 