### PR TITLE
Add referrer property when tracking Deep Link Opened

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -27,18 +27,14 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
-import android.net.ParseException;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
-
 import com.segment.analytics.internal.Utils;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsActivityLifecycleCallbacks.java
@@ -27,13 +27,18 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
+import android.net.ParseException;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.Lifecycle;
 import androidx.lifecycle.LifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
+
+import com.segment.analytics.internal.Utils;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -172,6 +177,12 @@ class AnalyticsActivityLifecycleCallbacks
         }
 
         Properties properties = new Properties();
+
+        Uri referrer = Utils.getReferrer(activity);
+        if (referrer != null) {
+            properties.putReferrer(referrer.toString());
+        }
+
         Uri uri = intent.getData();
         try {
             for (String parameter : uri.getQueryParameterNames()) {

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -35,10 +35,13 @@ import static android.provider.Settings.Secure.ANDROID_ID;
 import static android.provider.Settings.Secure.getString;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Process;
 import android.telephony.TelephonyManager;
@@ -558,6 +561,36 @@ public final class Utils {
         }
         editor.apply();
     }
+
+    /** Returns the referrer who started the Activity. */
+    public static Uri getReferrer(Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            return activity.getReferrer();
+        }
+        return getReferrerCompatible(activity);
+    }
+
+    /** Returns the referrer on devices running SDK versions lower than 22. */
+    private static Uri getReferrerCompatible(Activity activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            Intent intent = activity.getIntent();
+            Uri referrerUri = intent.getParcelableExtra(Intent.EXTRA_REFERRER);
+            if (referrerUri != null) {
+                return referrerUri;
+            }
+            String referrer = intent.getStringExtra("android.intent.extra.REFERRER_NAME"); // Intent.EXTRA_REFERRER_NAME
+            if (referrer != null) {
+                // Try parsing the referrer URL; if it's invalid, return null
+                try {
+                    return Uri.parse(referrer);
+                } catch (android.net.ParseException e) {
+                    return null;
+                }
+            }
+        }
+        return null;
+    }
+
 
     private Utils() {
         throw new AssertionError("No instances");

--- a/analytics/src/main/java/com/segment/analytics/internal/Utils.java
+++ b/analytics/src/main/java/com/segment/analytics/internal/Utils.java
@@ -578,7 +578,8 @@ public final class Utils {
             if (referrerUri != null) {
                 return referrerUri;
             }
-            String referrer = intent.getStringExtra("android.intent.extra.REFERRER_NAME"); // Intent.EXTRA_REFERRER_NAME
+            // Intent.EXTRA_REFERRER_NAME
+            String referrer = intent.getStringExtra("android.intent.extra.REFERRER_NAME");
             if (referrer != null) {
                 // Try parsing the referrer URL; if it's invalid, return null
                 try {
@@ -590,7 +591,6 @@ public final class Utils {
         }
         return null;
     }
-
 
     private Utils() {
         throw new AssertionError("No instances");

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -1059,6 +1059,7 @@ open class AnalyticsTest {
             )
     }
 
+    @Config(sdk=[22])
     @Test
     fun trackDeepLinks() {
         Analytics.INSTANCES.clear()
@@ -1108,11 +1109,14 @@ open class AnalyticsTest {
         )
 
         val expectedURL = "app://track.com/open?utm_id=12345&gclid=abcd&nope="
+        val referrerUrl = "android-app:/com.package.app"
 
         val activity = Mockito.mock(Activity::class.java)
         val intent = Mockito.mock(Intent::class.java)
         val uri = Uri.parse(expectedURL)
+        val referrer = Uri.parse(referrerUrl)
 
+        whenever(activity.referrer).thenReturn(referrer)
         whenever(intent.data).thenReturn(uri)
         whenever(activity.intent).thenReturn(intent)
 
@@ -1124,15 +1128,91 @@ open class AnalyticsTest {
                     object : NoDescriptionMatcher<TrackPayload>() {
                         override fun matchesSafely(payload: TrackPayload): Boolean {
                             return payload.event() == "Deep Link Opened" &&
-                                payload.properties()
-                                .getString("url") == expectedURL &&
-                                payload.properties()
-                                .getString("gclid") == "abcd" &&
-                                payload.properties()
-                                .getString("utm_id") == "12345"
+                                payload.properties().getString("url") == expectedURL &&
+                                payload.properties().getString("gclid") == "abcd" &&
+                                payload.properties().getString("utm_id") == "12345" &&
+                                payload.properties().getString("referrer") == referrerUrl
                         }
                     })
             )
+    }
+
+    @Config(sdk=[18])
+    @Test
+    fun trackDeepLinks_api18() {
+        Analytics.INSTANCES.clear()
+
+        val callback =
+                AtomicReference<ActivityLifecycleCallbacks>()
+        doNothing()
+                .whenever(application)
+                .registerActivityLifecycleCallbacks(
+                        argThat<ActivityLifecycleCallbacks>(
+                                object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
+                                    override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
+                                        callback.set(item)
+                                        return true
+                                    }
+                                })
+                )
+
+        analytics = Analytics(
+                application,
+                networkExecutor,
+                stats,
+                traitsCache,
+                analyticsContext,
+                defaultOptions,
+                Logger.with(Analytics.LogLevel.NONE),
+                "qaz", listOf(factory),
+                client,
+                Cartographer.INSTANCE,
+                projectSettingsCache,
+                "foo",
+                DEFAULT_FLUSH_QUEUE_SIZE,
+                DEFAULT_FLUSH_INTERVAL.toLong(),
+                analyticsExecutor,
+                true,
+                CountDownLatch(0),
+                false,
+                true,
+                optOut,
+                Crypto.none(), emptyList(), emptyMap(),
+                jsMiddleware,
+                ValueMap(),
+                lifecycle,
+                false,
+                true,
+                DEFAULT_API_HOST
+        )
+
+        val expectedURL = "app://track.com/open?utm_id=12345&gclid=abcd&nope="
+        val referrerUrl = "android-app:/com.package.app"
+
+        val activity = Mockito.mock(Activity::class.java)
+        val intent = Mockito.mock(Intent::class.java)
+        val uri = Uri.parse(expectedURL)
+        val referrer = Uri.parse(referrerUrl)
+
+        whenever(intent.getParcelableExtra<Uri>(Intent.EXTRA_REFERRER)).thenReturn(referrer)
+        whenever(intent.data).thenReturn(uri)
+        whenever(activity.intent).thenReturn(intent)
+
+        callback.get().onActivityCreated(activity, Bundle())
+
+        verify(integration)
+                .track(
+                        argThat<TrackPayload>(
+                                object : NoDescriptionMatcher<TrackPayload>() {
+                                    override fun matchesSafely(payload: TrackPayload): Boolean {
+                                        return payload.event() == "Deep Link Opened" &&
+                                                payload.properties().getString("url") == expectedURL &&
+                                                payload.properties().getString("gclid") == "abcd" &&
+                                                payload.properties().getString("utm_id") == "12345" &&
+                                                payload.properties().getString("referrer") == referrerUrl
+                                    }
+                                })
+                )
     }
 
     @Test

--- a/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
+++ b/analytics/src/test/java/com/segment/analytics/AnalyticsTest.kt
@@ -1059,7 +1059,7 @@ open class AnalyticsTest {
             )
     }
 
-    @Config(sdk=[22])
+    @Config(sdk = [22])
     @Test
     fun trackDeepLinks() {
         Analytics.INSTANCES.clear()
@@ -1137,53 +1137,53 @@ open class AnalyticsTest {
             )
     }
 
-    @Config(sdk=[18])
+    @Config(sdk = [18])
     @Test
     fun trackDeepLinks_api18() {
         Analytics.INSTANCES.clear()
 
         val callback =
-                AtomicReference<ActivityLifecycleCallbacks>()
+            AtomicReference<ActivityLifecycleCallbacks>()
         doNothing()
-                .whenever(application)
-                .registerActivityLifecycleCallbacks(
-                        argThat<ActivityLifecycleCallbacks>(
-                                object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
-                                    override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
-                                        callback.set(item)
-                                        return true
-                                    }
-                                })
-                )
+            .whenever(application)
+            .registerActivityLifecycleCallbacks(
+                argThat<ActivityLifecycleCallbacks>(
+                    object : NoDescriptionMatcher<ActivityLifecycleCallbacks>() {
+                        override fun matchesSafely(item: ActivityLifecycleCallbacks): Boolean {
+                            callback.set(item)
+                            return true
+                        }
+                    })
+            )
 
         analytics = Analytics(
-                application,
-                networkExecutor,
-                stats,
-                traitsCache,
-                analyticsContext,
-                defaultOptions,
-                Logger.with(Analytics.LogLevel.NONE),
-                "qaz", listOf(factory),
-                client,
-                Cartographer.INSTANCE,
-                projectSettingsCache,
-                "foo",
-                DEFAULT_FLUSH_QUEUE_SIZE,
-                DEFAULT_FLUSH_INTERVAL.toLong(),
-                analyticsExecutor,
-                true,
-                CountDownLatch(0),
-                false,
-                true,
-                optOut,
-                Crypto.none(), emptyList(), emptyMap(),
-                jsMiddleware,
-                ValueMap(),
-                lifecycle,
-                false,
-                true,
-                DEFAULT_API_HOST
+            application,
+            networkExecutor,
+            stats,
+            traitsCache,
+            analyticsContext,
+            defaultOptions,
+            Logger.with(Analytics.LogLevel.NONE),
+            "qaz", listOf(factory),
+            client,
+            Cartographer.INSTANCE,
+            projectSettingsCache,
+            "foo",
+            DEFAULT_FLUSH_QUEUE_SIZE,
+            DEFAULT_FLUSH_INTERVAL.toLong(),
+            analyticsExecutor,
+            true,
+            CountDownLatch(0),
+            false,
+            true,
+            optOut,
+            Crypto.none(), emptyList(), emptyMap(),
+            jsMiddleware,
+            ValueMap(),
+            lifecycle,
+            false,
+            true,
+            DEFAULT_API_HOST
         )
 
         val expectedURL = "app://track.com/open?utm_id=12345&gclid=abcd&nope="
@@ -1201,18 +1201,18 @@ open class AnalyticsTest {
         callback.get().onActivityCreated(activity, Bundle())
 
         verify(integration)
-                .track(
-                        argThat<TrackPayload>(
-                                object : NoDescriptionMatcher<TrackPayload>() {
-                                    override fun matchesSafely(payload: TrackPayload): Boolean {
-                                        return payload.event() == "Deep Link Opened" &&
-                                                payload.properties().getString("url") == expectedURL &&
-                                                payload.properties().getString("gclid") == "abcd" &&
-                                                payload.properties().getString("utm_id") == "12345" &&
-                                                payload.properties().getString("referrer") == referrerUrl
-                                    }
-                                })
-                )
+            .track(
+                argThat<TrackPayload>(
+                    object : NoDescriptionMatcher<TrackPayload>() {
+                        override fun matchesSafely(payload: TrackPayload): Boolean {
+                            return payload.event() == "Deep Link Opened" &&
+                                payload.properties().getString("url") == expectedURL &&
+                                payload.properties().getString("gclid") == "abcd" &&
+                                payload.properties().getString("utm_id") == "12345" &&
+                                payload.properties().getString("referrer") == referrerUrl
+                        }
+                    })
+            )
     }
 
     @Test


### PR DESCRIPTION
Following this tutorial https://clmirror.storage.googleapis.com/codelabs/deeplink-referrer/index.html?index=..%2F..index#5, we now have the ability to track the referrer for the `Deep Link Opened` event. This value can be either the website url or the app package name that contained the deep link.