### PR TITLE
release 4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 Version 4.11.0 (Jan 6, 2023)
 ============================
-* [Fix](https://github.com/segmentio/analytics-android/pull/817): move writeKey from http request header to payload body
+* [New](https://github.com/segmentio/analytics-android/pull/817): move writeKey from http request header to payload body
 
 Version 4.10.4 (Feb 17, 2022)
 ============================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 4.11.0 (Jan 6, 2023)
+============================
+* [Fix](https://github.com/segmentio/analytics-android/pull/817): move writeKey from http request header to payload body
+
 Version 4.10.4 (Feb 17, 2022)
 ============================
 * [Fix](https://github.com/segmentio/analytics-android/pull/791): fix ANR issue caused by MediaDRM api

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.segment.analytics.android
 
-VERSION_CODE=4105
-VERSION_NAME=4.10.5
+VERSION_CODE=4110
+VERSION_NAME=4.11.0
 
 POM_NAME=Segment for Android
 POM_DESCRIPTION=The hassle-free way to add analytics to your Android app.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 GROUP=com.segment.analytics.android
 
-VERSION_CODE=4110
-VERSION_NAME=4.11.0
+VERSION_CODE=4111
+VERSION_NAME=4.11.1
 
 POM_NAME=Segment for Android
 POM_DESCRIPTION=The hassle-free way to add analytics to your Android app.


### PR DESCRIPTION
* [New](https://github.com/segmentio/analytics-android/pull/817): move writeKey from http request header to payload body
