### PR TITLE
fix WindowManager crash on android 11+

### DIFF
--- a/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
+++ b/analytics/src/main/java/com/segment/analytics/AnalyticsContext.java
@@ -340,10 +340,17 @@ public class AnalyticsContext extends ValueMap {
      */
     void putScreen(Context context) {
         Map<String, Object> screen = createMap();
-        WindowManager manager = getSystemService(context, Context.WINDOW_SERVICE);
-        Display display = manager.getDefaultDisplay();
         DisplayMetrics displayMetrics = new DisplayMetrics();
-        display.getMetrics(displayMetrics);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            context.getDisplay().getRealMetrics(displayMetrics);
+        }
+        else {
+            WindowManager manager = getSystemService(context, Context.WINDOW_SERVICE);
+            Display display = manager.getDefaultDisplay();
+            display.getMetrics(displayMetrics);
+        }
+
         screen.put(SCREEN_DENSITY_KEY, displayMetrics.density);
         screen.put(SCREEN_HEIGHT_KEY, displayMetrics.heightPixels);
         screen.put(SCREEN_WIDTH_KEY, displayMetrics.widthPixels);


### PR DESCRIPTION
fixed the issue mentioned in #726. use the implementation proposed [here](https://github.com/segmentio/analytics-android/issues/726#issuecomment-730482599).